### PR TITLE
[API-925] Update and expand auth instructions.

### DIFF
--- a/versions/v2/content/authentication.md
+++ b/versions/v2/content/authentication.md
@@ -17,29 +17,28 @@ You must replace <strong>YOUR-PERSONAL-API-TOKEN</strong> with your personal API
 </aside>
 
 Our Living Documentation and API Explorer are located in [Swagger](https://app.swaggerhub.com/apis/CobaltLab/cobalt-api/)
-and built with the [OpenAPI specification](https://swagger.io/specification/).  To explore our API
-from Swagger, complete the following steps:
+and built with the [OpenAPI specification](https://swagger.io/specification/).
+To explore our API, complete the following steps:
 
 - Create and copy your API token from your [Cobalt profile](https://app.cobalt.io/settings/api-token).
-- Go to [Swagger](https://app.swaggerhub.com/apis/CobaltLab/cobalt-api/) and click the green
+- Go to [Swagger](https://app.swaggerhub.com/apis/CobaltLab/cobalt-api/) and select the green
   _Authorize_ button on the right side of the screen.
-- Paste your API token into the `ApiToken` input.
-- Click the green _Authorize_ button below the `ApiToken` input.  The word `Authorized` should
-  appear underneath the `ApiToken` input.
-- Close the dialog box by clicking either _Close_ button.
-- Scroll down in the right endpoints column until you see the `Orgs` section.
-- Click the `GET /orgs` endpoint to expand it.
-- Click the _Try it out_ button, then click the _Execute_ button.
-- Scroll down to the `Response body` section.  Depending on how many orgs you belong to, you should
-  see one or more `resource` sections within the output.  Each of those sections should contain a
-  `token` field.  Select the org you want to experiment with and copy the `token` field value.  This
-  is your Org Token.
-- Return back to the _Authorize_ section.
-- Paste the Org Token into the `OrgToken` input and click the green _Authorize_ button below it.
-  The word `Authorized` should appear underneath the `OrgToken` input.
-- Close the dialog box again by clicking either _Close_ button.
-- All subsequent requests to `/assets`, `/findings`, `/pentests`, etc. will be scoped to your
-  personal API token and the organization selected.
+- Paste your API token into the `ApiToken` text box.
+- Select the green _Authorize_ button below the `ApiToken` input.  You should see `Authorized` below
+  the `ApiToken` label.
+- Close the Available Authorizations dialog box.
+
+Most (but not all) API calls are scoped to a specific organization.  This is done via the
+`X-Org-Token` header.  Any operations that require this will have that header as a required field.
+
+To see which organizations you belong to:
+
+- Search for the `Orgs` endpoint.
+- Select the `GET /orgs` operation to expand it.
+- Select the _Try it out_ button, and then select the _Execute_ button (note that you do **not**
+  need to provide the `X-Org-Token` header here).
+- Scroll down to the `Response body`. Copy the `token` associated with your target organization
+  (`org`). This is your Org Token and should be provided in the `X-Org-Token` header when required.
 
 <aside class="warning">
 If your organization uses SAML for authentication with Cobalt, API tokens are not currently disabled when a user is

--- a/versions/v2/content/authentication.md
+++ b/versions/v2/content/authentication.md
@@ -28,8 +28,8 @@ To explore our API, complete the following steps:
   the `ApiToken` label.
 - Close the Available Authorizations dialog box.
 
-Most (but not all) API calls are scoped to a specific organization.  This is done via the
-`X-Org-Token` header.  Any operations that require this will have that header as a required field.
+Most API calls are scoped to a specific organization, with the `X-Org-Token` header.  We include
+that header, as needed, in our API calls.
 
 To see which organizations you belong to:
 
@@ -38,7 +38,7 @@ To see which organizations you belong to:
 - Select the _Try it out_ button, and then select the _Execute_ button (note that you do **not**
   need to provide the `X-Org-Token` header here).
 - Scroll down to the `Response body`. Copy the `token` associated with your target organization
-  (`org`). This is your Org Token and should be provided in the `X-Org-Token` header when required.
+  (`org`). This is your Org Token.  Include it with the `X-Org-Token` header when required.
 
 <aside class="warning">
 If your organization uses SAML for authentication with Cobalt, API tokens are not currently disabled when a user is

--- a/versions/v2/content/authentication.md
+++ b/versions/v2/content/authentication.md
@@ -17,17 +17,29 @@ You must replace <strong>YOUR-PERSONAL-API-TOKEN</strong> with your personal API
 </aside>
 
 Our Living Documentation and API Explorer are located in [Swagger](https://app.swaggerhub.com/apis/CobaltLab/cobalt-api/)
-and built with the [OpenAPI specification](https://swagger.io/specification/).
+and built with the [OpenAPI specification](https://swagger.io/specification/).  To explore our API
+from Swagger, complete the following steps:
 
-- Create and copy your token from your [Cobalt profile](https://app.cobalt.io/settings/api-token).
-- Go to [Swagger](https://app.swaggerhub.com/apis/CobaltLab/cobalt-api/) and click the _Authorize_ button.
-- Paste your token into the `ApiKeyAuth` input.
-- Call the `/orgs` endpoint (Try it out => Execute).
-- Copy the `token` value from response body.
-- Return back to the _Authorize_ section and add the copied organization `token` into the `OrgToken` input field, and
-  click to _Authorize_ button again.
-- Now, all subsequent requests to `/assets`, `/findings`, `/pentests`, etc. will be scoped to your personal API token
-  and the organization selected.
+- Create and copy your API token from your [Cobalt profile](https://app.cobalt.io/settings/api-token).
+- Go to [Swagger](https://app.swaggerhub.com/apis/CobaltLab/cobalt-api/) and click the green
+  _Authorize_ button on the right side of the screen.
+- Paste your API token into the `ApiToken` input.
+- Click the green _Authorize_ button below the `ApiToken` input.  The word `Authorized` should
+  appear underneath the `ApiToken` input.
+- Close the dialog box by clicking either _Close_ button.
+- Scroll down in the right endpoints column until you see the `Orgs` section.
+- Click the `GET /orgs` endpoint to expand it.
+- Click the _Try it out_ button, then click the _Execute_ button.
+- Scroll down to the `Response body` section.  Depending on how many orgs you belong to, you should
+  see one or more `resource` sections within the output.  Each of those sections should contain a
+  `token` field.  Select the org you want to experiment with and copy the `token` field value.  This
+  is your Org Token.
+- Return back to the _Authorize_ section.
+- Paste the Org Token into the `OrgToken` input and click the green _Authorize_ button below it.
+  The word `Authorized` should appear underneath the `OrgToken` input.
+- Close the dialog box again by clicking either _Close_ button.
+- All subsequent requests to `/assets`, `/findings`, `/pentests`, etc. will be scoped to your
+  personal API token and the organization selected.
 
 <aside class="warning">
 If your organization uses SAML for authentication with Cobalt, API tokens are not currently disabled when a user is


### PR DESCRIPTION
Updated the instructions to reflect the renaming of the `ApiKeyAuth` scheme to `ApiToken`.  Also expanded and cleaned up.