### PR TITLE
[API-1062] Add Duplicate Pentest endpoint. Update changelog.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ node_modules/
 
 # netlify CLI tmp folder
 .netlify/
+
+.idea/

--- a/versions/v2/content/changelog.md
+++ b/versions/v2/content/changelog.md
@@ -19,6 +19,7 @@ the following endpoints for more details:
 - [Upload an Asset Logo](./#upload-a-logo)
 - [Get a Pentest](./#get-a-pentest)
 - [Get a Pentest Report](./#get-a-pentest-report)
+- [Duplicate a Pentest](./#duplicate-a-pentest)
 - [Get a Finding](./#get-a-finding)
 - [View Available Finding States](./#view-available-finding-states)
 - [Update Finding State](./#update-finding-state)

--- a/versions/v2/content/pentests.md
+++ b/versions/v2/content/pentests.md
@@ -326,7 +326,6 @@ Remember - you can only request the report for a pentest scoped to the organizat
 <code>X-Org-Token</code> header.
 </aside>
 
-
 ## Duplicate a Pentest
 
 ```sh
@@ -336,9 +335,10 @@ curl -X POST "https://api.cobalt.io/pentests/YOUR-PENTEST-IDENTIFIER/duplicate" 
   -H "X-Org-Token: YOUR-V2-ORGANIZATION-TOKEN"
 ```
 
-This endpoint duplicates a pentest based on the identifier provided and creates a new pentest. The pentest identifier has to be a valid pentest that belong to the organization specified in the `X-Org-Token` header. 
-Note there is **no JSON body** required for this endpoint. The new pentest will be in **Draft state** and will have the same settings as the pentest provided in the identifier.   
-
+This endpoint duplicates a pentest based on the identifier provided and creates a new pentest.
+The pentest identifier has to be a valid pentest that belong to the organization specified in the `X-Org-Token` header.
+Note there is **no JSON body** required for this endpoint.
+The new pentest will be in **Draft state** and will have the same settings as the pentest provided in the identifier.
 
 ### HTTP Request
 

--- a/versions/v2/content/pentests.md
+++ b/versions/v2/content/pentests.md
@@ -335,9 +335,9 @@ curl -X POST "https://api.cobalt.io/pentests/YOUR-PENTEST-IDENTIFIER/duplicate" 
   -H "X-Org-Token: YOUR-V2-ORGANIZATION-TOKEN"
 ```
 
-This endpoint duplicates a pentest based on the identifier provided and creates a new pentest.
-The pentest identifier has to point to a valid pentest that belongs to the organization specified in the `X-Org-Token` header.
-Note there is **no JSON body** required for this endpoint.
+This endpoint creates a duplicate pentest based on the identifier provided.
+The pentest to be duplicated must exist and belong to the organization specified in the `X-Org-Token` header.
+Note there is **no Request body** required for this endpoint.
 Note that you **cannot** duplicate a pentest that is in Draft state.
 The new pentest will be in **Draft state** and will have the same brief as the pentest provided in the identifier.
 

--- a/versions/v2/content/pentests.md
+++ b/versions/v2/content/pentests.md
@@ -325,3 +325,30 @@ issue.
 Remember - you can only request the report for a pentest scoped to the organization specified in the
 <code>X-Org-Token</code> header.
 </aside>
+
+
+## Duplicate a Pentest
+
+```sh
+curl -X POST "https://api.cobalt.io/pentests/YOUR-PENTEST-IDENTIFIER/duplicate" \
+  -H "Accept: application/vnd.cobalt.v2+json" \
+  -H "Authorization: Bearer YOUR-PERSONAL-API-TOKEN" \
+  -H "X-Org-Token: YOUR-V2-ORGANIZATION-TOKEN"
+```
+
+This endpoint duplicates a pentest based on the identifier provided and creates a new pentest. The pentest identifier has to be a valid pentest that belong to the organization specified in the `X-Org-Token` header. 
+Note there is **no JSON body** required for this endpoint. The new pentest will be in **Draft state** and will have the same settings as the pentest provided in the identifier.   
+
+
+### HTTP Request
+
+`POST https://api.cobalt.io/pentests/YOUR-PENTEST-IDENTIFIER-HERE/duplicate`
+
+### Response
+
+On success, a `201` response code will be returned. A response header, `Location`, will contain the URL
+within Cobalt's API of the new duplicated pentest.
+
+<aside class="notice">
+Remember - you can only request a pentest scoped to the organization specified in the <code>X-Org-Token</code> header.
+</aside>

--- a/versions/v2/content/pentests.md
+++ b/versions/v2/content/pentests.md
@@ -336,9 +336,10 @@ curl -X POST "https://api.cobalt.io/pentests/YOUR-PENTEST-IDENTIFIER/duplicate" 
 ```
 
 This endpoint duplicates a pentest based on the identifier provided and creates a new pentest.
-The pentest identifier has to be a valid pentest that belong to the organization specified in the `X-Org-Token` header.
+The pentest identifier has to point to a valid pentest that belongs to the organization specified in the `X-Org-Token` header.
 Note there is **no JSON body** required for this endpoint.
-The new pentest will be in **Draft state** and will have the same settings as the pentest provided in the identifier.
+Note that you **cannot** duplicate a pentest that is in Draft state.
+The new pentest will be in **Draft state** and will have the same brief as the pentest provided in the identifier.
 
 ### HTTP Request
 
@@ -347,8 +348,8 @@ The new pentest will be in **Draft state** and will have the same settings as th
 ### Response
 
 On success, a `201` response code will be returned. A response header, `Location`, will contain the URL
-within Cobalt's API of the new duplicated pentest.
+within Cobalt's API of the new pentest.
 
 <aside class="notice">
-Remember - you can only request a pentest scoped to the organization specified in the <code>X-Org-Token</code> header.
+Remember - you can only duplicate a pentest within the organization specified in the <code>X-Org-Token</code> header.
 </aside>


### PR DESCRIPTION
Ticket: [API-1062](https://zombie.atlassian.net/browse/API-1062)

Please review the paragraph text for "duplicate a pentest."  

**Highlights**
- the pentest id has to be a valid ID. 
- the pentest being duplicated has to belong to the org in the x-org-token
- the newly duplicated pentest will be created in Draft state with the same "settings" as the one being duplicated. 
- there is **no json** body for this POST endpoint. 
- I updated the changelog also. 