### PR TITLE
API-1238: Fix enum examples

### DIFF
--- a/versions/v2/content/pentests.md
+++ b/versions/v2/content/pentests.md
@@ -34,7 +34,7 @@ curl -X GET "https://api.cobalt.io/pentests" \
         ],
         "methodology": "web",
         "targets": [
-          "https://example.com",
+          "https://cobalt.io",
           "192.168.1.1"
         ],
         "start_date": "Dec 11 2019",
@@ -116,7 +116,7 @@ curl -X GET "https://api.cobalt.io/pentests/YOUR-PENTEST-IDENTIFIER" \
       ],
       "methodology": "web",
       "targets": [
-        "https://example.com",
+        "https://cobalt.io",
         "192.168.1.1"
       ],
       "start_date": "Dec 11 2019",
@@ -315,11 +315,11 @@ issue.
 
 ### Accepted Risk Response Fields
 
-| Field                  | Description |
-|------------------------|-|
-| `finding_id`           | A unique ID representing the finding. Starts with `vl_`. |
+| Field                  | Description                                                                                                                                                                       |
+|------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `finding_id`           | A unique ID representing the finding. Starts with `vl_`.                                                                                                                          |
 | `accepted_risk_reason` | One of `low_severity`, `mitigated_by_waf`, `mitigated_by_other`, `no_longer_relevant`, `third_party_dependencies`, `internal_dependencies`, `intended_functionality`, or `other`. |
-| `state`                | The state of the finding. |
+| `state`                | The state of the finding.                                                                                                                                                         |
 
 <aside class="notice">
 Remember - you can only request the report for a pentest scoped to the organization specified in the
@@ -369,11 +369,11 @@ curl -X POST "https://api.cobalt.io/pentests" \
             "asset_id": "as_4L4ZjKgfzP7VBwUmqCZmmL",
             "title": "Pentest Title",
             "description": "Pentest description.",
-            "technology_stack": "A description of the technology stack(s) in use.",
+            "technology_stack": "A comma separated list of technologies in use.",
             "instructions": "Instructions for the pentest.",
             "additional_requests": "Special requests or instructions to the pentester.",
             "test_credentials": "Credentials to be used for the pentest.",
-            "test_credentials_option": "Additional details about credentials.",
+            "test_credentials_option": "One of the following: provided, distributed, not_required",
             "targets": "A list of URLs and/or endpoints to be pentested.",
             "scoping": {
               "api": {
@@ -396,17 +396,17 @@ organization specified in the `X-Org-Token` header.  The pentest will be in the 
 
 ### Body
 
-| Field                     | Description |
-|---------------------------|-|
-| `asset_id`                | The ID of the asset being pentested; this asset must exist and belong to the organization specified in the `X-Org-Token` header. |
-| `title`                   | The title of the pentest. |
-| `description`             | A description of the pentest. |
-| `technology_stack`        | A description of the technology stack(s) in use; for example, C# or Ruby on Rails. |
-| `instructions`            | Optional; if present, instructions for the pentester(s). |
-| `additional_requests`     | Optional; if present, special requests or instructions for the pentester(s). |
-| `test_credentials`        | Optional; if present, credentials to be used by the pentester(s). |
-| `test_credentials_option` | Optional; if present, additional information about the credentials. |
-| `targets`                 | Optional; if present, the URL(s), endpoint(s), etc being targeted by the pentest. |
+| Field                     | Description                                                                                                                                              |
+|---------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `asset_id`                | The ID of the asset being pentested; this asset must exist and belong to the organization specified in the `X-Org-Token` header.                         |
+| `title`                   | The title of the pentest.                                                                                                                                |
+| `description`             | A description of the pentest.                                                                                                                            |
+| `technology_stack`        | A comma separated list of technologies in use; for example, "Ruby, Go, C#"                                                                               |
+| `instructions`            | Optional; if present, instructions for the pentester(s).                                                                                                 |
+| `additional_requests`     | Optional; if present, special requests or instructions for the pentester(s).                                                                             |
+| `test_credentials`        | Optional; if present, credentials to be used by the pentester(s).                                                                                        |
+| `test_credentials_option` | Optional; if present, additional information about the credentials. Must be one of the following: `provided`, `distributed`, `not_required`              |
+| `targets`                 | Optional; if present, the URL(s), endpoint(s), etc. being targeted by the pentest. A comma separated list; "1.1.1.1, https://cobalt.io"                  |
 | `scoping`                 | Optional; if present, information about the size of the pentest.  For details, refer to the [Scoping Body Fields](./#scoping-body-fields) section below. |
 
 ### Scoping Body Fields
@@ -415,16 +415,16 @@ If scoping data is provided, it must match the type of the asset being pentested
 the asset being pentested is of type `API`, the API-related scoping fields should be filled in.
 
 | Field                          | Description |
-|--------------------------------|-|
-| `api.num_of_endpoints`         | The number of API endpoints to be pentested. |
-| `api.num_of_roles`             | The number of roles to be pentested per API endpoint. |
-| `cloud_config.num_of_services` | The number of cloud services to be pentested. |
-| `cloud_config.num_of_accounts` | The number of roles to be pentested per cloud service. |
-| `mobile.num_of_views`          | The number of mobile app views to be pentested. |
+|--------------------------------|----------------------------------------------------------|
+| `api.num_of_endpoints`         | The number of API endpoints to be pentested.             |
+| `api.num_of_roles`             | The number of roles to be pentested per API endpoint.    |
+| `cloud_config.num_of_services` | The number of cloud services to be pentested.            |
+| `cloud_config.num_of_accounts` | The number of roles to be pentested per cloud service.   |
+| `mobile.num_of_views`          | The number of mobile app views to be pentested.          |
 | `mobile.num_of_roles`          | The number of roles to be pentested per mobile app view. |
-| `network.num_of_ips`           | The number of network IP addresses to be pentested. |
-| `web.num_of_pages`             | The number of web pages to be pentested. |
-| `web.num_of_roles`             | The number of roles to be pentested per web page. |
+| `network.num_of_ips`           | The number of network IP addresses to be pentested.      |
+| `web.num_of_pages`             | The number of web pages to be pentested.                 |
+| `web.num_of_roles`             | The number of roles to be pentested per web page.        |
 
 ### Response
 
@@ -473,35 +473,35 @@ This endpoint updates a pentest from the information provided.
 
 ### Body
 
-| Field                     | Description |
-|---------------------------|-|
-| `asset_id`                | The ID of the asset being pentested; this asset must exist and belong to the organization specified in the `X-Org-Token` header. |
-| `title`                   | The title of the pentest. |
-| `description`             | A description of the pentest. |
-| `technology_stack`        | A description of the technology stack(s) in use; for example, C# or Ruby on Rails. |
-| `instructions`            | Optional; if present, instructions for the pentester(s). |
-| `additional_requests`     | Optional; if present, special requests or instructions for the pentester(s). |
-| `test_credentials`        | Optional; if present, credentials to be used by the pentester(s). |
-| `test_credentials_option` | Optional; if present, additional information about the credentials. |
-| `targets`                 | Optional; if present, the URL(s), endpoint(s), etc being targeted by the pentest. |
-| `scoping`                 | Optional; if present, information about the size of the pentest.  For details, refer to the [Scoping Body Fields](./#scoping-body-fields) section below. |
+| Field                     | Description                                                                                                                                               |
+|---------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `asset_id`                | The ID of the asset being pentested; this asset must exist and belong to the organization specified in the `X-Org-Token` header.                          |
+| `title`                   | The title of the pentest.                                                                                                                                 |
+| `description`             | A description of the pentest.                                                                                                                             |
+| `technology_stack`        | A description of the technology stack(s) in use; for example, C# or Ruby on Rails.                                                                        |
+| `instructions`            | Optional; if present, instructions for the pentester(s).                                                                                                  |
+| `additional_requests`     | Optional; if present, special requests or instructions for the pentester(s).                                                                              |
+| `test_credentials`        | Optional; if present, credentials to be used by the pentester(s).                                                                                         |
+| `test_credentials_option` | Optional; if present, additional information about the credentials.                                                                                       |
+| `targets`                 | Optional; if present, the URL(s), endpoint(s), etc being targeted by the pentest.                                                                         |
+| `scoping`                 | Optional; if present, information about the size of the pentest.  For details, refer to the [Scoping Body Fields](./#scoping-body-fields) section below.  |
 
 ### Scoping Body Fields
 
 If scoping data is provided, it must match the type of the asset being pentested.  For example, if
 the asset being pentested is of type `API`, the API-related scoping fields should be filled in.
 
-| Field                          | Description |
-|--------------------------------|-|
-| `api.num_of_endpoints`         | The number of API endpoints to be pentested. |
-| `api.num_of_roles`             | The number of roles to be pentested per API endpoint. |
-| `cloud_config.num_of_services` | The number of cloud services to be pentested. |
-| `cloud_config.num_of_accounts` | The number of roles to be pentested per cloud service. |
-| `mobile.num_of_views`          | The number of mobile app views to be pentested. |
+| Field                          | Description                                              |
+|--------------------------------|----------------------------------------------------------|
+| `api.num_of_endpoints`         | The number of API endpoints to be pentested.             |
+| `api.num_of_roles`             | The number of roles to be pentested per API endpoint.    |
+| `cloud_config.num_of_services` | The number of cloud services to be pentested.            |
+| `cloud_config.num_of_accounts` | The number of roles to be pentested per cloud service.   |
+| `mobile.num_of_views`          | The number of mobile app views to be pentested.          |
 | `mobile.num_of_roles`          | The number of roles to be pentested per mobile app view. |
-| `network.num_of_ips`           | The number of network IP addresses to be pentested. |
-| `web.num_of_pages`             | The number of web pages to be pentested. |
-| `web.num_of_roles`             | The number of roles to be pentested per web page. |
+| `network.num_of_ips`           | The number of network IP addresses to be pentested.      |
+| `web.num_of_pages`             | The number of web pages to be pentested.                 |
+| `web.num_of_roles`             | The number of roles to be pentested per web page.        |
 
 ### Response
 

--- a/versions/v2/content/update-finding-state.md
+++ b/versions/v2/content/update-finding-state.md
@@ -62,6 +62,7 @@ This endpoint retrieves the current state of a finding as well as possible next 
 ```sh
 curl -X PATCH "https://api.cobalt.io/findings/YOUR-FINDING-ID" \
   -H "Accept: application/vnd.cobalt.v2+json" \
+  -H 'Content-Type: application/vnd.cobalt.v2+json' \
   -H "Authorization: Bearer YOUR-PERSONAL-API-TOKEN" \
   -H "X-Org-Token: YOUR-V2-ORGANIZATION-TOKEN" \
   -d '{"state":"triaging"}'


### PR DESCRIPTION
Change the documentation to reflect the following:

- `technology_stack` looks better on app-web when presented as a comma-separated list. E.g. "Ruby, Go, C#"
- `test_credentials_option` must be one of following: `provided`, `distributed`, `not_required` - otherwise the API returns 400.
- `targets` looks better on app-web when presented as a comma-separated list. E.g. "1.1.1.1, https://foobar.com"
- `Content-Type` is a required header when updating the finding state. But it's missing in the examples.

[Background & discussion](https://cobalthq.slack.com/archives/C021EK29SGY/p1661514545796489) on Slack