### PR TITLE
[API-1274] Add Pentest Type to the GET Documentation

### DIFF
--- a/versions/v2/content/pentests.md
+++ b/versions/v2/content/pentests.md
@@ -77,7 +77,7 @@ This endpoint retrieves a list of all pentests that belong to the organization s
 | `title`         | The title of the returned pentest.                                                  |
 | `objectives`    | The objectives of the pentest. E.g. "Coverage of OWASP Top 10"                      |
 | `asset_id`      | ID of the asset that the returned pentest belongs to                                |
-| `testing_type`  | Pentest Testing Type, where can be: internal, agile and comprehensive               |
+| `testing_type`  | Pentest testing type, where can be: internal, agile and comprehensive               |
 | `platform_tags` | Tech stack of the target. E.g. java, kotlin, ruby, aws, and so on.                  |
 | `methodology`   | Pentest methodology. Web, API, Web+API, Mobile, External Network and so on.         |
 | `targets`       | Targetted IP addresses, domains, services, and so on.                               |
@@ -148,7 +148,7 @@ This endpoint retrieves a specific pentest that belongs to the organization spec
 | `title`         | The title of the returned pentest.                                                  |
 | `objectives`    | The objectives of the pentest. E.g. "Coverage of OWASP Top 10"                      |
 | `asset_id`      | ID of the asset that the returned pentest belongs to                                |
-| `testing_type`  | Pentest Testing Type, where can be: internal, agile and comprehensive               |
+| `testing_type`  | Pentest testing type, where can be: internal, agile and comprehensive               |
 | `platform_tags` | Tech stack of the target. E.g. java, kotlin, ruby, aws, and so on.                  |
 | `methodology`   | Pentest methodology. Web, API, Web+API, Mobile, External Network and so on.         |
 | `targets`       | Targetted IP addresses, domains, services, and so on.                               |

--- a/versions/v2/content/pentests.md
+++ b/versions/v2/content/pentests.md
@@ -27,6 +27,7 @@ curl -X GET "https://api.cobalt.io/pentests" \
         "state": "new",
         "tag": "#PT5940",
         "asset_id": "as_4L4ZjKgfzP7VBwUmqCZmmL",
+        "testing_type": "agile",
         "platform_tags": [
           "rails",
           "ruby",
@@ -76,6 +77,7 @@ This endpoint retrieves a list of all pentests that belong to the organization s
 | `title`         | The title of the returned pentest.                                                  |
 | `objectives`    | The objectives of the pentest. E.g. "Coverage of OWASP Top 10"                      |
 | `asset_id`      | ID of the asset that the returned pentest belongs to                                |
+| `testing_type`  | Pentest Testing Type, where can be: internal, agile and comprehensive               |
 | `platform_tags` | Tech stack of the target. E.g. java, kotlin, ruby, aws, and so on.                  |
 | `methodology`   | Pentest methodology. Web, API, Web+API, Mobile, External Network and so on.         |
 | `targets`       | Targetted IP addresses, domains, services, and so on.                               |
@@ -109,6 +111,7 @@ curl -X GET "https://api.cobalt.io/pentests/YOUR-PENTEST-IDENTIFIER" \
       "state": "new",
       "tag": "#PT5940",
       "asset_id": "as_4L4ZjKgfzP7VBwUmqCZmmL",
+      "testing_type": "agile",
       "platform_tags": [
         "rails",
         "ruby",
@@ -145,6 +148,7 @@ This endpoint retrieves a specific pentest that belongs to the organization spec
 | `title`         | The title of the returned pentest.                                                  |
 | `objectives`    | The objectives of the pentest. E.g. "Coverage of OWASP Top 10"                      |
 | `asset_id`      | ID of the asset that the returned pentest belongs to                                |
+| `testing_type`  | Pentest Testing Type, where can be: internal, agile and comprehensive               |
 | `platform_tags` | Tech stack of the target. E.g. java, kotlin, ruby, aws, and so on.                  |
 | `methodology`   | Pentest methodology. Web, API, Web+API, Mobile, External Network and so on.         |
 | `targets`       | Targetted IP addresses, domains, services, and so on.                               |

--- a/versions/v2/content/pentests.md
+++ b/versions/v2/content/pentests.md
@@ -77,7 +77,7 @@ This endpoint retrieves a list of all pentests that belong to the organization s
 | `title`         | The title of the returned pentest.                                                  |
 | `objectives`    | The objectives of the pentest. E.g. "Coverage of OWASP Top 10"                      |
 | `asset_id`      | ID of the asset that the returned pentest belongs to                                |
-| `testing_type`  | Pentest testing type, where can be: internal, agile and comprehensive               |
+| `testing_type`  | Pentest testing type, where can be: internal, agile or comprehensive                |
 | `platform_tags` | Tech stack of the target. E.g. java, kotlin, ruby, aws, and so on.                  |
 | `methodology`   | Pentest methodology. Web, API, Web+API, Mobile, External Network and so on.         |
 | `targets`       | Targetted IP addresses, domains, services, and so on.                               |
@@ -148,7 +148,7 @@ This endpoint retrieves a specific pentest that belongs to the organization spec
 | `title`         | The title of the returned pentest.                                                  |
 | `objectives`    | The objectives of the pentest. E.g. "Coverage of OWASP Top 10"                      |
 | `asset_id`      | ID of the asset that the returned pentest belongs to                                |
-| `testing_type`  | Pentest testing type, where can be: internal, agile and comprehensive               |
+| `testing_type`  | Pentest testing type, where can be: internal, agile or comprehensive                |
 | `platform_tags` | Tech stack of the target. E.g. java, kotlin, ruby, aws, and so on.                  |
 | `methodology`   | Pentest methodology. Web, API, Web+API, Mobile, External Network and so on.         |
 | `targets`       | Targetted IP addresses, domains, services, and so on.                               |


### PR DESCRIPTION
Add testing_type to Pentest documentation
This is not really in the scope of API-1274, but I think it is necessary. 

--------
I am not sure why the building is failing because of markdowns. 
[✖] https://cobalt.io/" → Status: 400
