### PR TITLE
API-1288: Upgrade go, hugo and docuapi

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/cobalthq/cobalt-public-api-docs
 
-go 1.18
+go 1.19
 
-require github.com/bep/docuapi/v2 v2.1.0 // indirect
+require github.com/bep/docuapi/v2 v2.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/bep/docuapi/v2 v2.1.0 h1:PMOKqMQ/UoZ/iufcQBrEzsI78ZdQq+szySsND8JKceU=
 github.com/bep/docuapi/v2 v2.1.0/go.mod h1:61SkJTCwqcIBqpMsUokAjyljnSiRHV74idrhPF2f+os=
+github.com/bep/docuapi/v2 v2.2.0 h1:rd5R3XZMjp45lXpfjPM9+C0Prt2pJzgiHXvdA2U48Mw=
+github.com/bep/docuapi/v2 v2.2.0/go.mod h1:61SkJTCwqcIBqpMsUokAjyljnSiRHV74idrhPF2f+os=
 github.com/gohugoio/hugo-mod-jslibs-dist/alpinejs/v3 v3.21000.20200/go.mod h1:WWQxcmPs5Xy3xDgi29ipkmZT6NKVb3bsqyCDTY3eYYY=
 github.com/olivernn/lunr.js v2.3.9+incompatible/go.mod h1:yEkQ1DUSMtNsn8n2CqvQXZd0ErWPEG8g9QRmblR+KS8=
 github.com/slatedocs/slate v2.9.2+incompatible/go.mod h1:n698aXLkExWIlF7prJey0Kq6wlKIKvj/stVb5oouZDM=

--- a/netlify.toml
+++ b/netlify.toml
@@ -2,19 +2,19 @@
 command = "hugo --gc --minify --config='versions/v1/config.yaml' && hugo --gc --minify --config='versions/v2/config.yaml'"
 
 [context.production.environment]
-HUGO_VERSION = "0.100.1"
+HUGO_VERSION = "0.102.3"
 
 [context.deploy-preview]
 command = "hugo --gc --minify --buildFuture --config='versions/v1/config.yaml' && hugo --gc --minify --buildFuture --config='versions/v2/config.yaml'"
 
 [context.deploy-preview.environment]
-HUGO_VERSION = "0.100.1"
+HUGO_VERSION = "0.102.3"
 
 [context.branch-deploy]
 command = "hugo --gc --minify --buildFuture --config='versions/v1/config.yaml' && hugo --gc --minify --buildFuture --config='versions/v2/config.yaml'"
 
 [context.branch-deploy.environment]
-HUGO_VERSION = "0.100.1"
+HUGO_VERSION = "0.102.3"
 
 [[redirects]]
   from = "/"


### PR DESCRIPTION
### Changes

- Upgrade `go` from 1.18 to 1.19
- Upgrade `docuapi` from 2.1.0 to 2.2.0
- Upgrade `hugo` from 0.100.1 to 0.102.3