### PR TITLE
API-1368: Add sample JSON to Webhook Events

### DIFF
--- a/versions/v2/content/pentests.md
+++ b/versions/v2/content/pentests.md
@@ -286,14 +286,14 @@ issue.
 ### Response Fields
 
 | Field            | Description |
-|------------------|-|
+|------------------|----------------------------------------------------------|
 | `id`             | A unique ID representing the pentest. Starts with `pt_`. |
 | `title`          | The title of the returned pentest. |
 | `state`          | One of `live`, `remediation`, or `closed` (reports can not be generated for pentests in other states). |
 | `asset.id`       | The unique ID representing the asset associated with this pentest.  Starts with `as_`. |
 | `pentesters`     | A list of the pentesters who performed this pentest. |
 | `report`         | A summary of this pentest's findings and recommendations. |
-| `findings`       | A list of the findings broken down by both `severity` and `state`. `severity` is not a required field so some findings may appear in the `state` section but not in `severity`.  For a list of the valid `severity` keys, refer to the table in the [Calculations](./#calculations) section.  For a list of valid `state` keys refer to the [State](./#state) section. |
+| `findings`       | A list of the findings broken down by both `severity` and `state`. `severity` is not a required field so some findings may appear in the `state` section but not in `severity`. For a list of the valid `severity` keys, refer to the table in the [Calculations](./#calculations) section.  For a list of valid `state` keys refer to the [State](./#state) section. |
 | `accepted_risks` | A list of the findings that have been accepted as risks. For details, refer to the [Accepted Risk Response Fields](./#accepted-risk-response-fields) section below. |
 | `links.ui.url`   | A link to redirect an authorized user to this pentest in the Cobalt web application. |
 
@@ -373,12 +373,12 @@ curl -X POST "https://api.cobalt.io/pentests" \
             "asset_id": "as_4L4ZjKgfzP7VBwUmqCZmmL",
             "title": "Pentest Title",
             "description": "Pentest description.",
-            "technology_stack": "A comma separated list of technologies in use.",
-            "instructions": "Instructions for the pentest.",
-            "additional_requests": "Special requests or instructions to the pentester.",
-            "test_credentials": "Credentials to be used for the pentest.",
-            "test_credentials_option": "One of the following: provided, distributed, not_required",
-            "targets": "A list of URLs and/or endpoints to be pentested.",
+            "technology_stack": "ruby, golang, rails, kotlin",
+            "instructions": "The pentest target is the v1 endpoints",
+            "additional_requests": "Do not test webhook endpoints.",
+            "test_credentials": "Account: foobar, password: foobar",
+            "test_credentials_option": "provided",
+            "targets": "1.1.1.1, https://google.com",
             "testing_type": "comprehensive",
             "scoping": {
               "api": {
@@ -454,12 +454,12 @@ curl -X PUT "https://api.cobalt.io/pentests/YOUR-PENTEST-IDENTIFIER" \
             "asset_id": "as_4L4ZjKgfzP7VBwUmqCZmmL",
             "title": "Pentest Title",
             "description": "Pentest description.",
-            "technology_stack": "A description of the technology stack(s) in use.",
-            "instructions": "Instructions for the pentest.",
-            "additional_requests": "Special requests or instructions to the pentester.",
-            "test_credentials": "Credentials to be used for the pentest.",
-            "test_credentials_option": "Additional details about credentials.",
-            "targets": "A list of URLs and/or endpoints to be pentested.",
+            "technology_stack": "ruby, golang, rails, kotlin",
+            "instructions": "The pentest target is the v1 endpoints",
+            "additional_requests": "Do not test webhook endpoints.",
+            "test_credentials": "Account: foobar, password: foobar",
+            "test_credentials_option": "provided",
+            "targets": "1.1.1.1, https://google.com",
             "testing_type": "comprehensive",
             "scoping": {
               "api": {

--- a/versions/v2/content/webhooks.md
+++ b/versions/v2/content/webhooks.md
@@ -49,22 +49,22 @@ This endpoint retrieves a list of all webhooks that belong to your organization.
 
 ### URL Parameters
 
-| Parameter | Default | Description                                                                                            |
-|-----------|---------|--------------------------------------------------------------------------------------------------------|
-| `cursor`  | N/A     | Used for [pagination](./#pagination), e.g. `https://api.cobalt.io/webhooks?cursor=a1b2c3d4`            |
+| Parameter | Default | Description                                                                                              |
+|-----------|---------|----------------------------------------------------------------------------------------------------------|
+| `cursor`  | N/A     | Used for [pagination](./#pagination), e.g. `https://api.cobalt.io/webhooks?cursor=a1b2c3d4`              |
 | `limit`   | `10`    | If specified, returns only a specified amount of webhooks, e.g. `https://api.cobalt.io/webhooks?limit=5` |
 
 ### Response Fields
 
-| Field                | Description                                                         |
-|----------------------|---------------------------------------------------------------------|
-| id                   | The ID of the webhook                                               |
-| name                 | The name of the webhook                                             |
-| url                  | The URL that webhook events are sent to                             |
-| active               | A boolean flag that indicates if the webhook is active              |
-| unhealthy_since      | The time that we began failing to deliver events to this webhook. If the webhook is unhealthy, this field will contain an ISO8601 time stamp. Ex: `2022-08-30T14:14:14.000Z`                                                                   |
-| authentication_token | We include this value in the `X-Authentication-Token` header when we send webhook events to you. You can use this to verify that the events you receive are really from Cobalt.                                                                          |
-| user                 | The ID of the user that created the webhook                         |
+| Field                | Description                                            |
+|----------------------|--------------------------------------------------------|
+| id                   | The ID of the webhook                                  |
+| name                 | The name of the webhook                                |
+| url                  | The URL that webhook events are sent to                |
+| active               | A boolean flag that indicates if the webhook is active |
+| unhealthy_since      | The time that we began failing to deliver events to this webhook. If the webhook is unhealthy, this field will contain an ISO8601 time stamp. Ex: `2022-08-30T14:14:14.000Z`    |
+| authentication_token | We include this value in the `X-Authentication-Token` header when we send webhook events to you. You can use this to verify that the events you receive are really from Cobalt. |
+| user                 | The ID of the user that created the webhook            |
 
 ## Get a webhook
 
@@ -105,8 +105,8 @@ This endpoint retrieves a specific webhook belonging to your organization.
 | name                 | The name of the webhook                                             |
 | url                  | The URL that webhook events are sent to                             |
 | active               | A boolean flag that indicates if the webhook is active              |
-| unhealthy_since      | The time that we began failing to deliver events to this webhook. If the webhook is unhealthy, this field will contain an ISO8601 time stamp. Ex: `2022-08-30T14:14:14.000Z`                                                                   |
-| authentication_token | We include this value in the `X-Authentication-Token` header when we send webhook events to you. You can use this to verify that the events you receive are really from Cobalt.                                                                          |
+| unhealthy_since      | The time that we began failing to deliver events to this webhook. If the webhook is unhealthy, this field will contain an ISO8601 time stamp. Ex: `2022-08-30T14:14:14.000Z`    |
+| authentication_token | We include this value in the `X-Authentication-Token` header when we send webhook events to you. You can use this to verify that the events you receive are really from Cobalt. |
 | user                 | The ID of the user that created the webhook                         |
 
 <aside class="notice">
@@ -149,7 +149,7 @@ test events, see the [Webhook Events](./#webhook-events) section below.
 |----------------------|----------------------------------------------------------|
 | name                 | The name of the webhook                                  |
 | active               | A boolean flag specifying if the webhook is active       |
-| authentication_token | An arbitrary string value. We include this value in the `X-Authentication-Token` header when we send webhook events to you. You can use this to verify that the events you receive are really from Cobalt.                                    |
+| authentication_token | An arbitrary string value. We include this value in the `X-Authentication-Token` header when we send webhook events to you. You can use this to verify that the events you receive are really from Cobalt. |
 | url                  | The URL to send events to                                |
 
 ### Response
@@ -196,7 +196,7 @@ All body fields are optional. You only need to include the fields that should be
 | Field                | Description                                        |
 |----------------------|----------------------------------------------------|
 | name                 | The name of the webhook                            |
-| authentication_token | An arbitrary string value. We include this value in the `X-Authentication-Token` header when we send webhook events to you. You can use this to verify that the events you receive are really from Cobalt.                              |
+| authentication_token | An arbitrary string value. We include this value in the `X-Authentication-Token` header when we send webhook events to you. You can use this to verify that the events you receive are really from Cobalt. |
 | active               | A boolean flag specifying if the webhook is active |
 | url                  | The URL to send events to                          |
 
@@ -241,6 +241,7 @@ Remember - you can only delete a webhook within the organization specified in th
 ## Webhook Events
 
 Webhook event properties:
+
 | Field         | Description                                |
 |---------------|--------------------------------------------|
 | id            | The ID of the webhook event                |
@@ -248,23 +249,36 @@ Webhook event properties:
 | subject       | The subject that the event is related to   |
 | timestamp     | The time that the event ocurred            |
 
-Action types:
+`action` types:
 
-* TEST_EVENT
-* PENTEST_CREATED
-* FINDING_PUBLISHED
+* `TEST_EVENT`
+* `PENTEST_CREATED`
+* `FINDING_PUBLISHED`
 
-Subject properties:
+`subject` properties:
+
 | Field         | Description                                |
 |---------------|--------------------------------------------|
 | id            | The ID of the subject resource             |
 | type          | The type of the subject resource           |
 
-Subject types:
+`subject` types:
 
-* TEST_EVENT
-* PENTEST
-* FINDING
+* `TEST_EVENT`
+* `PENTEST`
+* `FINDING`
+
+```json
+{
+  "id": "eve_4tvptSU2SyqupRGQ4Jawdx",
+  "action": "PENTEST_CREATED",
+  "subject": {
+    "id": "eve_4tvptSU2SyqupRGQ4Jawdx",
+    "type": "PENTEST"
+  },
+  "timestamp": "2022-09-17T17:14:06.734Z"
+}
+```
 
 ## Webhook Delivery and Health
 

--- a/versions/v2/content/webhooks.md
+++ b/versions/v2/content/webhooks.md
@@ -254,6 +254,7 @@ Webhook event properties:
 * `TEST_EVENT`
 * `PENTEST_CREATED`
 * `FINDING_PUBLISHED`
+* `FINDING_STATE_UPDATED`
 
 `subject` properties:
 


### PR DESCRIPTION
### Changes:

- [Replace instructions in pentest examples with real examples](https://github.com/cobalthq/cobalt-api-docs/commit/5b4522ccbd5c1bad79c561487ebe5e4d62c269b4)
- [Add sample JSON to Webhook Events](https://github.com/cobalthq/cobalt-api-docs/commit/24d5ef68018b624d222a84d542e12d1f82dbd3ff)
- [Add missing FINDING_STATE_UPDATED event type](https://github.com/cobalthq/cobalt-api-docs/pull/120/commits/403bee54ab069e2cf097e06948a9728e56c945cf)