### PR TITLE
[API-1543] Pin GitHub Actions to SHAs

### DIFF
--- a/.github/workflows/auto_merge.yml
+++ b/.github/workflows/auto_merge.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - name: Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v1.3.5
+        uses: dependabot/fetch-metadata@5ef00187930bafb52d529e0b9c3dff045dfa9851 # v1.3.5
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
       - name: Approve a PR

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,15 +7,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
       - name: Check markdown files to detect broken links
-        uses: gaurav-nelson/github-action-markdown-link-check@1.0.14
+        uses: gaurav-nelson/github-action-markdown-link-check@9710f0fec812ce0a3b98bef4c9d842fc1f39d976 # 1.0.14
         with:
           folder-path: 'versions/v1/content, versions/v2/content'
           use-quiet-mode: 'no'
           use-verbose-mode: 'yes'
       - name: Lint markdown files
-        uses: avto-dev/markdown-lint@v1.5.0
+        uses: avto-dev/markdown-lint@04d43ee9191307b50935a753da3b775ab695eceb # v1.5.0
         with:
           args: 'versions/**/content/*.md'
           config: '.markdownlint.yaml'

--- a/.github/workflows/vale.yml
+++ b/.github/workflows/vale.yml
@@ -9,10 +9,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
 
       - name: Vale Grammar Linter
-        uses: errata-ai/vale-action@reviewdog
+        uses: errata-ai/vale-action@c4213d4de3d5f718b8497bd86161531c78992084 # v2.0.1
         with:
           fail_on_error: true
           files: versions/


### PR DESCRIPTION
Pin all GitHub Actions we use to the commit SHA of the latest release in the same major version as we were using. Note, for the `vale-action`, the use of `reviewdog` referenced a branch and v2.0.1 points to an older commit on that branch.

This should improve reproducibility and security.
