### PR TITLE
[FND-2076] Add docs for EUDC support, udpate examples base url

### DIFF
--- a/versions/v1/content/assets.md
+++ b/versions/v1/content/assets.md
@@ -8,7 +8,7 @@ title: Assets
 ## Get All Assets
 
 ```sh
-curl -X GET "https://api.cobalt.io/assets" \
+curl -X GET "https://api.us.cobalt.io/assets" \
   -H "Accept: application/vnd.cobalt.v1+json" \
   -H "Authorization: Bearer YOUR-PERSONAL-API-TOKEN" \
   -H "X-Org-Token: YOUR-V1-ORGANIZATION-TOKEN"
@@ -35,7 +35,7 @@ curl -X GET "https://api.cobalt.io/assets" \
       },
       "links": {
         "ui": {
-          "url": "https://api.cobalt.io/links/eyJ0eXBlIjoic29tZXRoaW5nIiwib3JnU2x1ZyI6ImNvYmFsdCIsInBlbnRlc3RUYWciOiJz="
+          "url": "https://api.us.cobalt.io/links/eyJ0eXBlIjoic29tZXRoaW5nIiwib3JnU2x1ZyI6ImNvYmFsdCIsInBlbnRlc3RUYWciOiJz="
         }
       }
     }
@@ -51,14 +51,14 @@ This endpoint retrieves a list of assets that belong to the organization specifi
 
 ### HTTP Request
 
-`GET https://api.cobalt.io/assets`
+`GET https://api.us.cobalt.io/assets`
 
 ### URL Parameters
 
 | Parameter | Default | Description                                                                                              |
 |-----------|---------|----------------------------------------------------------------------------------------------------------|
-| `cursor`  | N/A     | Used for [pagination](./#pagination). Example: `https://api.cobalt.io/assets?cursor=a1b2c3d4`            |
-| `limit`   | `10`    | If specified, returns only a specified amount of assets. Example: `https://api.cobalt.io/assets?limit=5` |
+| `cursor`  | N/A     | Used for [pagination](./#pagination). Example: `https://api.us.cobalt.io/assets?cursor=a1b2c3d4`            |
+| `limit`   | `10`    | If specified, returns only a specified amount of assets. Example: `https://api.us.cobalt.io/assets?limit=5` |
 
 ### Response Fields
 

--- a/versions/v1/content/events.md
+++ b/versions/v1/content/events.md
@@ -8,7 +8,7 @@ title: Events
 ## Get All Events
 
 ```sh
-curl -X GET "https://api.cobalt.io/events" \
+curl -X GET "https://api.us.cobalt.io/events" \
   -H "Accept: application/vnd.cobalt.v1+json" \
   -H "Authorization: Bearer YOUR-PERSONAL-API-TOKEN"
 ```
@@ -63,11 +63,11 @@ This endpoint retrieves a list of all events for your account.
 
 ### HTTP Request
 
-`GET https://api.cobalt.io/events`
+`GET https://api.us.cobalt.io/events`
 
 ### URL Parameters
 
 | Parameter | Default | Description                                                                                              |
 |-----------|---------|----------------------------------------------------------------------------------------------------------|
-| `cursor`  | N/A     | Used for [pagination](./#pagination). Example: `https://api.cobalt.io/events?cursor=a1b2c3d4`            |
-| `limit`   | `10`    | If specified, returns only a specified amount of events. Example: `https://api.cobalt.io/events?limit=5` |
+| `cursor`  | N/A     | Used for [pagination](./#pagination). Example: `https://api.us.cobalt.io/events?cursor=a1b2c3d4`            |
+| `limit`   | `10`    | If specified, returns only a specified amount of events. Example: `https://api.us.cobalt.io/events?limit=5` |

--- a/versions/v1/content/findings.md
+++ b/versions/v1/content/findings.md
@@ -8,7 +8,7 @@ title: Findings
 ## Get All Findings
 
 ```sh
-curl -X GET "https://api.cobalt.io/findings" \
+curl -X GET "https://api.us.cobalt.io/findings" \
   -H "Accept: application/vnd.cobalt.v1+json" \
   -H "Authorization: Bearer YOUR-PERSONAL-API-TOKEN" \
   -H "X-Org-Token: YOUR-V1-ORGANIZATION-TOKEN"
@@ -72,7 +72,7 @@ curl -X GET "https://api.cobalt.io/findings" \
       },
       "links": {
         "ui": {
-          "url": "https://api.cobalt.io/links/eyJ0eXBlIjoic29tZXRoaW5nIiwib3JnU2x1ZyI6ImNvYmFsdCIsInBlbnRlc3RUYWciOiJz="
+          "url": "https://api.us.cobalt.io/links/eyJ0eXBlIjoic29tZXRoaW5nIiwib3JnU2x1ZyI6ImNvYmFsdCIsInBlbnRlc3RUYWciOiJz="
         }
       }
     }
@@ -111,20 +111,20 @@ Cobalt Risk Classification (`severity`, a.k.a. `criticality`):
 
 ### HTTP Request
 
-`GET https://api.cobalt.io/findings`
+`GET https://api.us.cobalt.io/findings`
 
-`GET https://api.cobalt.io/findings?pentest=pt_9Ig1234`
+`GET https://api.us.cobalt.io/findings?pentest=pt_9Ig1234`
 
-`GET https://api.cobalt.io/findings?asset=as_cwrsqsL`
+`GET https://api.us.cobalt.io/findings?asset=as_cwrsqsL`
 
 ### URL Parameters
 
 | Parameter | Default | Description                                                                                                            |
 |-----------|---------|------------------------------------------------------------------------------------------------------------------------|
-| `cursor`  | N/A     | Used for [pagination](./#pagination). Example: `https://api.cobalt.io/findings?cursor=a1b2c3d4`                        |
-| `limit`   | `1000`  | If specified, returns only a specified amount of findings. Example: `https://api.cobalt.io/findings?limit=5`           |
-| `pentest` | N/A     | If specified, returns findings scoped to this pentest id. Example: `https://api.cobalt.io/findings?pentest=pt_9Ig1234` |
-| `asset`   | N/A     | If specified, returns findings scoped to this asset id. Example: `https://api.cobalt.io/findings?asset=as_cwrsqsL`     |
+| `cursor`  | N/A     | Used for [pagination](./#pagination). Example: `https://api.us.cobalt.io/findings?cursor=a1b2c3d4`                        |
+| `limit`   | `1000`  | If specified, returns only a specified amount of findings. Example: `https://api.us.cobalt.io/findings?limit=5`           |
+| `pentest` | N/A     | If specified, returns findings scoped to this pentest id. Example: `https://api.us.cobalt.io/findings?pentest=pt_9Ig1234` |
+| `asset`   | N/A     | If specified, returns findings scoped to this asset id. Example: `https://api.us.cobalt.io/findings?asset=as_cwrsqsL`     |
 
 ### Response Fields
 

--- a/versions/v1/content/orgs.md
+++ b/versions/v1/content/orgs.md
@@ -8,7 +8,7 @@ title: Organizations
 ## Get All Organizations
 
 ```sh
-curl -X GET "https://api.cobalt.io/orgs" \
+curl -X GET "https://api.us.cobalt.io/orgs" \
   -H "Accept: application/vnd.cobalt.v1+json" \
   -H "Authorization: Bearer YOUR-PERSONAL-API-TOKEN"
 ```
@@ -26,7 +26,7 @@ curl -X GET "https://api.cobalt.io/orgs" \
       },
       "links": {
         "ui": {
-          "url": "https://api.cobalt.io/links/eyJ0eXBlIjoic29tZXRoaW5nIiwib3JnU2x1ZyI6ImNvYmFsdCIsInBlbnRlc3RUYWciOiJz="
+          "url": "https://api.us.cobalt.io/links/eyJ0eXBlIjoic29tZXRoaW5nIiwib3JnU2x1ZyI6ImNvYmFsdCIsInBlbnRlc3RUYWciOiJz="
         }
       }
     },
@@ -38,7 +38,7 @@ curl -X GET "https://api.cobalt.io/orgs" \
       },
       "links": {
         "ui": {
-          "url": "https://api.cobalt.io/links/eyJ0eXBlIjoic29tZXRoaW5nIiwib3JnU2x1ZyI6ImNvYmFsdCIsInBlbnRlc3RUYWciOiJz="
+          "url": "https://api.us.cobalt.io/links/eyJ0eXBlIjoic29tZXRoaW5nIiwib3JnU2x1ZyI6ImNvYmFsdCIsInBlbnRlc3RUYWciOiJz="
         }
       }
     }
@@ -56,14 +56,14 @@ organization.
 
 ### HTTP Request
 
-`GET https://api.cobalt.io/orgs`
+`GET https://api.us.cobalt.io/orgs`
 
 ### URL Parameters
 
 | Parameter | Default | Description                                                                                                   |
 |-----------|---------|---------------------------------------------------------------------------------------------------------------|
-| `cursor`  | N/A     | Used for [pagination](./#pagination). Example: `https://api.cobalt.io/orgs?cursor=a1b2c3d4`                   |
-| `limit`   | `10`    | If specified, returns only a specified amount of organizations. Example: `https://api.cobalt.io/orgs?limit=5` |
+| `cursor`  | N/A     | Used for [pagination](./#pagination). Example: `https://api.us.cobalt.io/orgs?cursor=a1b2c3d4`                   |
+| `limit`   | `10`    | If specified, returns only a specified amount of organizations. Example: `https://api.us.cobalt.io/orgs?limit=5` |
 
 ### Response Fields
 

--- a/versions/v1/content/pagination.md
+++ b/versions/v1/content/pagination.md
@@ -12,7 +12,7 @@ To paginate append the `next_page` or `prev_page` value to the base API URL.
 For example, if the `next_page` value in a response is `/resource?cursor=a1b2c3d4` you can send the following request
 for the next page.
 
-`GET https://api.cobalt.io/resource?cursor=a1b2c3d4`
+`GET https://api.us.cobalt.io/resource?cursor=a1b2c3d4`
 
 <aside class="notice">
 Remember - there is always a default value for the <code>limit</code> query parameter.

--- a/versions/v1/content/pentests.md
+++ b/versions/v1/content/pentests.md
@@ -8,7 +8,7 @@ title: Pentests
 ## Get All Pentests
 
 ```sh
-curl -X GET "https://api.cobalt.io/pentests" \
+curl -X GET "https://api.us.cobalt.io/pentests" \
   -H "Accept: application/vnd.cobalt.v1+json" \
   -H "Authorization: Bearer YOUR-PERSONAL-API-TOKEN" \
   -H "X-Org-Token: YOUR-V1-ORGANIZATION-TOKEN"
@@ -42,7 +42,7 @@ curl -X GET "https://api.cobalt.io/pentests" \
       },
       "links": {
         "ui": {
-          "url": "https://api.cobalt.io/links/eyJ0eXBlIjoic29tZXRoaW5nIiwib3JnU2x1ZyI6ImNvYmFsdCIsInBlbnRlc3RUYWciOiJz="
+          "url": "https://api.us.cobalt.io/links/eyJ0eXBlIjoic29tZXRoaW5nIiwib3JnU2x1ZyI6ImNvYmFsdCIsInBlbnRlc3RUYWciOiJz="
         }
       }
     }
@@ -58,15 +58,15 @@ This endpoint retrieves a list of all pentests that belong to the organization s
 
 ### HTTP Request
 
-`GET https://api.cobalt.io/pentests`
+`GET https://api.us.cobalt.io/pentests`
 
 ### URL Parameters
 
 | Parameter | Default | Description                                                                                                        |
 |-----------|---------|--------------------------------------------------------------------------------------------------------------------|
-| `asset`   | N/A     | If specified, returns pentests scoped to this asset id. Example: `https://api.cobalt.io/pentests?asset=as_rvZRC5Y` |
-| `cursor`  | N/A     | Used for [pagination](./#pagination). Example: `https://api.cobalt.io/pentests?cursor=a1b2c3d4`                    |
-| `limit`   | `1000`  | If specified, returns only a specified amount of pentests. Example: `https://api.cobalt.io/pentests?limit=5`       |
+| `asset`   | N/A     | If specified, returns pentests scoped to this asset id. Example: `https://api.us.cobalt.io/pentests?asset=as_rvZRC5Y` |
+| `cursor`  | N/A     | Used for [pagination](./#pagination). Example: `https://api.us.cobalt.io/pentests?cursor=a1b2c3d4`                    |
+| `limit`   | `1000`  | If specified, returns only a specified amount of pentests. Example: `https://api.us.cobalt.io/pentests?limit=5`       |
 
 ### Response Fields
 

--- a/versions/v1/content/tokens.md
+++ b/versions/v1/content/tokens.md
@@ -8,7 +8,7 @@ title: Tokens
 ## Get All Tokens
 
 ```sh
-curl -X GET "https://api.cobalt.io/tokens" \
+curl -X GET "https://api.us.cobalt.io/tokens" \
   -H "Accept: application/vnd.cobalt.v1+json" \
   -H "Authorization: Bearer YOUR-PERSONAL-API-TOKEN"
 ```
@@ -38,14 +38,14 @@ This endpoint retrieves a list of all tokens that belong to you.
 
 ### HTTP Request
 
-`GET https://api.cobalt.io/tokens`
+`GET https://api.us.cobalt.io/tokens`
 
 ### URL Parameters
 
 | Parameter | Default | Description                                                                                              |
 |-----------|---------|----------------------------------------------------------------------------------------------------------|
-| `cursor`  | N/A     | Used for [pagination](./#pagination). Example: `https://api.cobalt.io/tokens?cursor=a1b2c3d4`            |
-| `limit`   | `10`    | If specified, returns only a specified amount of tokens. Example: `https://api.cobalt.io/tokens?limit=5` |
+| `cursor`  | N/A     | Used for [pagination](./#pagination). Example: `https://api.us.cobalt.io/tokens?cursor=a1b2c3d4`            |
+| `limit`   | `10`    | If specified, returns only a specified amount of tokens. Example: `https://api.us.cobalt.io/tokens?limit=5` |
 
 ### Response Fields
 
@@ -59,7 +59,7 @@ This endpoint retrieves a list of all tokens that belong to you.
 ## Refresh Token
 
 ```sh
-curl -X POST "https://api.cobalt.io/tokens/YOUR-TOKEN-ID/refresh" \
+curl -X POST "https://api.us.cobalt.io/tokens/YOUR-TOKEN-ID/refresh" \
   -H "Accept: application/vnd.cobalt.v1+json" \
   -H "Authorization: Bearer YOUR-PERSONAL-API-TOKEN"
 ```
@@ -91,7 +91,7 @@ revoke the old token you've forgotten, and generate a new token.
 
 ### HTTP Request
 
-`POST https://api.cobalt.io/tokens/YOUR-TOKEN-ID/refresh`
+`POST https://api.us.cobalt.io/tokens/YOUR-TOKEN-ID/refresh`
 
 ### Response Fields
 

--- a/versions/v2/content/assets.md
+++ b/versions/v2/content/assets.md
@@ -8,7 +8,7 @@ title: Assets
 ## Get All Assets
 
 ```sh
-curl -X GET "https://api.cobalt.io/assets" \
+curl -X GET "https://api.us.cobalt.io/assets" \
   -H "Accept: application/vnd.cobalt.v2+json" \
   -H "Authorization: Bearer YOUR-PERSONAL-API-TOKEN" \
   -H "X-Org-Token: YOUR-V2-ORGANIZATION-TOKEN"
@@ -46,7 +46,7 @@ curl -X GET "https://api.cobalt.io/assets" \
       },
       "links": {
         "ui": {
-          "url": "https://api.cobalt.io/links/eyJ0eXBlIjoic29tZXRoaW5nIiwib3JnU2x1ZyI6ImNvYmFsdCIsInBlbnRlc3RUYWciOiJz="
+          "url": "https://api.us.cobalt.io/links/eyJ0eXBlIjoic29tZXRoaW5nIiwib3JnU2x1ZyI6ImNvYmFsdCIsInBlbnRlc3RUYWciOiJz="
         }
       }
     }
@@ -62,17 +62,17 @@ This endpoint retrieves a list of assets that belong to the organization specifi
 
 ### HTTP Request
 
-`GET https://api.cobalt.io/assets`
+`GET https://api.us.cobalt.io/assets`
 
 ### URL Parameters
 
 | Parameter             | Default | Description                                                                                                                                                                                                                                                                                   |
 |-----------------------|---------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `cursor`              | N/A     | Used for [pagination](./#pagination). Example: `https://api.cobalt.io/assets?cursor=a1b2c3d4`                                                                                                                                                                                                 |
-| `limit`               | `10`    | If specified, returns only a specified amount of assets. Example: `https://api.cobalt.io/assets?limit=5`                                                                                                                                                                                      |
-| `asset_type`          | N/A     | If specified, returns assets that match `asset_type`. See Response Fields below for example `asset_type` values. Example: `https://api.cobalt.io/assets?asset_type=web`. Returns an empty list if no assets match the `asset_type` filter.                                                    |
-| `tags_contains_all[]` | N/A     | If specified, returns assets that contain all matching `tags`. This query parameter can be specified multiple times. Returns an empty list if no matches are found. Example: `https://api.cobalt.io/assets?tags_contains_all[]=third party&tags_contains_all[]=some-tag-id`                   |
-| `sort`                | N/A     | If specified, returns assets sorted by one of the chosen parameters: `asset_type`. When defined, records are returned in ascending order by the sort parameter. To return in descending order, use a `-` before the sort parameter. Example: `https://api.cobalt.io/assets?sort=-asset_type`. |
+| `cursor`              | N/A     | Used for [pagination](./#pagination). Example: `https://api.us.cobalt.io/assets?cursor=a1b2c3d4`                                                                                                                                                                                                 |
+| `limit`               | `10`    | If specified, returns only a specified amount of assets. Example: `https://api.us.cobalt.io/assets?limit=5`                                                                                                                                                                                      |
+| `asset_type`          | N/A     | If specified, returns assets that match `asset_type`. See Response Fields below for example `asset_type` values. Example: `https://api.us.cobalt.io/assets?asset_type=web`. Returns an empty list if no assets match the `asset_type` filter.                                                    |
+| `tags_contains_all[]` | N/A     | If specified, returns assets that contain all matching `tags`. This query parameter can be specified multiple times. Returns an empty list if no matches are found. Example: `https://api.us.cobalt.io/assets?tags_contains_all[]=third party&tags_contains_all[]=some-tag-id`                   |
+| `sort`                | N/A     | If specified, returns assets sorted by one of the chosen parameters: `asset_type`. When defined, records are returned in ascending order by the sort parameter. To return in descending order, use a `-` before the sort parameter. Example: `https://api.us.cobalt.io/assets?sort=-asset_type`. |
 
 ### Response Fields
 
@@ -95,7 +95,7 @@ Remember - you can only request assets scoped to the organization specified in t
 ## Get an Asset
 
 ```sh
-curl -X GET "https://api.cobalt.io/assets/YOUR-ASSET-IDENTIFIER" \
+curl -X GET "https://api.us.cobalt.io/assets/YOUR-ASSET-IDENTIFIER" \
   -H "Accept: application/vnd.cobalt.v2+json" \
   -H "Authorization: Bearer YOUR-PERSONAL-API-TOKEN" \
   -H "X-Org-Token: YOUR-V2-ORGANIZATION-TOKEN"
@@ -132,7 +132,7 @@ curl -X GET "https://api.cobalt.io/assets/YOUR-ASSET-IDENTIFIER" \
     },
     "links": {
       "ui": {
-        "url": "https://api.cobalt.io/links/eyJ0eXBlIjoic29tZXRoaW5nIiwib3JnU2x1ZyI6ImNvYmFsdCIsInBlbnRlc3RUYWciOiJz="
+        "url": "https://api.us.cobalt.io/links/eyJ0eXBlIjoic29tZXRoaW5nIiwib3JnU2x1ZyI6ImNvYmFsdCIsInBlbnRlc3RUYWciOiJz="
       }
     }
   }
@@ -143,7 +143,7 @@ This endpoint retrieves a specific asset belonging to the organization specified
 
 ### HTTP Request
 
-`GET https://api.cobalt.io/assets/YOUR-ASSET-IDENTIFIER`
+`GET https://api.us.cobalt.io/assets/YOUR-ASSET-IDENTIFIER`
 
 ### Response Fields
 
@@ -166,7 +166,7 @@ Remember - you can only request an asset scoped to the organization specified in
 ## Create an Asset
 
 ```sh
-curl -X POST "https://api.cobalt.io/assets" \
+curl -X POST "https://api.us.cobalt.io/assets" \
   -H 'Accept: application/vnd.cobalt.v2+json' \
   -H 'Authorization: Bearer YOUR-PERSONAL-API-TOKEN' \
   -H 'Content-Type: application/vnd.cobalt.v2+json' \
@@ -187,7 +187,7 @@ This endpoint creates a new asset belonging to the organization specified in the
 
 ### HTTP Request
 
-`POST https://api.cobalt.io/assets`
+`POST https://api.us.cobalt.io/assets`
 
 ### Body
 
@@ -210,7 +210,7 @@ Remember - you can only create an asset within the organization specified in the
 ## Update an Asset
 
 ```sh
-curl -X PUT 'https://api.cobalt.io/assets/AN-ASSET-IDENTIFIER' \
+curl -X PUT 'https://api.us.cobalt.io/assets/AN-ASSET-IDENTIFIER' \
   -H 'Accept: application/vnd.cobalt.v2+json' \
   -H 'Authorization: Bearer YOUR-PERSONAL-API-TOKEN' \
   -H 'Content-Type: application/vnd.cobalt.v2+json' \
@@ -230,7 +230,7 @@ This endpoint updates an asset belonging to the organization specified in the `X
 
 ### HTTP Request
 
-`PUT https://api.cobalt.io/assets/YOUR-ASSET-IDENTIFIER`
+`PUT https://api.us.cobalt.io/assets/YOUR-ASSET-IDENTIFIER`
 
 ### Body
 
@@ -252,7 +252,7 @@ Remember - you can only update an asset within the organization specified in the
 ## Delete an Asset
 
 ```sh
-curl -X DELETE 'https://api.cobalt.io/assets/YOUR-ASSET-IDENTIFIER' \
+curl -X DELETE 'https://api.us.cobalt.io/assets/YOUR-ASSET-IDENTIFIER' \
   -H 'Accept: application/vnd.cobalt.v2+json' \
   -H 'Authorization: Bearer YOUR-PERSONAL-API-TOKEN' \
   -H 'Content-Type: application/vnd.cobalt.v2+json' \
@@ -266,7 +266,7 @@ also delete all associated `tags` for the asset.
 
 ### HTTP Request
 
-`DELETE https://api.cobalt.io/assets/YOUR-ASSET-IDENTIFIER`
+`DELETE https://api.us.cobalt.io/assets/YOUR-ASSET-IDENTIFIER`
 
 ### Response
 
@@ -279,7 +279,7 @@ Remember - you can only delete an asset within the organization specified in the
 ## Upload an Attachment
 
 ```sh
-curl -X POST 'https://api.cobalt.io/assets/YOUR-ASSET-IDENTIFIER/attachments' \
+curl -X POST 'https://api.us.cobalt.io/assets/YOUR-ASSET-IDENTIFIER/attachments' \
   -H 'Accept: application/vnd.cobalt.v2+json' \
   -H 'Authorization: Bearer YOUR-PERSONAL-API-TOKEN' \
   -H 'Content-Type: multipart/form-data' \
@@ -295,7 +295,7 @@ This endpoint uploads a new attachment for an asset belonging to the organizatio
 
 ### HTTP Request
 
-`POST https://api.cobalt.io/assets/YOUR-ASSET-IDENTIFIER/attachments`
+`POST https://api.us.cobalt.io/assets/YOUR-ASSET-IDENTIFIER/attachments`
 
 ### Body
 
@@ -320,7 +320,7 @@ Remember - you can only upload an attachment for an asset within the organizatio
 ## Delete an Attachment
 
 ```sh
-curl -X DELETE 'https://api.cobalt.io/assets/YOUR-ASSET-IDENTIFIER/attachments/YOUR-ATTACHMENT-IDENTIFIER' \
+curl -X DELETE 'https://api.us.cobalt.io/assets/YOUR-ASSET-IDENTIFIER/attachments/YOUR-ATTACHMENT-IDENTIFIER' \
   -H 'Accept: application/vnd.cobalt.v2+json' \
   -H 'Authorization: Bearer YOUR-PERSONAL-API-TOKEN' \
   -H 'X-Org-Token: YOUR-V2-ORGANIZATION-TOKEN'
@@ -332,7 +332,7 @@ This endpoint deletes an attachment from an asset belonging to the organization 
 
 ### HTTP Request
 
-`DELETE https://api.cobalt.io/assets/YOUR-ASSET-IDENTIFIER/attachments/YOUR-ATTACHMENT-IDENTIFIER`
+`DELETE https://api.us.cobalt.io/assets/YOUR-ASSET-IDENTIFIER/attachments/YOUR-ATTACHMENT-IDENTIFIER`
 
 > You can obtain this URL from the `Location` response header of the create attachment endpoint, or build it by getting
 > the attachment identifier from the response data of the `GET /assets` endpoint.
@@ -349,7 +349,7 @@ Remember - you can only delete an attachment from an asset within the organizati
 ## Upload a Logo
 
 ```sh
-curl -X POST 'https://api.cobalt.io/assets/YOUR-ASSET-IDENTIFIER/logo' \
+curl -X POST 'https://api.us.cobalt.io/assets/YOUR-ASSET-IDENTIFIER/logo' \
   -H 'Accept: application/vnd.cobalt.v2+json' \
   -H 'Authorization: Bearer YOUR-PERSONAL-API-TOKEN' \
   -H 'Content-Type: multipart/form-data' \
@@ -365,7 +365,7 @@ means the old logo is removed and replaced by the new logo.
 
 ### HTTP Request
 
-`POST https://api.cobalt.io/assets/YOUR-ASSET-IDENTIFIER/logo`
+`POST https://api.us.cobalt.io/assets/YOUR-ASSET-IDENTIFIER/logo`
 
 ### Body
 

--- a/versions/v2/content/authentication.md
+++ b/versions/v2/content/authentication.md
@@ -1,5 +1,5 @@
 ---
-weight: 3
+weight: 4
 title: Authentication
 ---
 

--- a/versions/v2/content/eudatacenter.md
+++ b/versions/v2/content/eudatacenter.md
@@ -1,0 +1,24 @@
+---
+weight: 3
+title: EU Datacenter
+---
+
+# Using the EU Datacenter and the Cobalt API
+<aside class="notice">
+The information provided in this section is specifically tailored for customers who are using our EU Datacenter (app.eu.cobalt.io).
+</aside>
+
+## Introduction
+If you're using our EU Datacenter (app.eu.cobalt.io) and need to call our API, be aware that the base URL for API calls will differ from the examples in our documentation, which use the US version.
+## Procedure
+1. Identify the Base URL: The base URL for customers using our EU Datacenter is https://api.eu.cobalt.io. This is the URL you should use when making API calls.
+2. Replace the Base URL in Examples: All examples provided in our documentation use the US version of the base URL (https://api.us.cobalt.io). When following these examples, you will need to replace the US base URL with the EU base URL.
+3. For example, if an API call in the documentation is shown as:
+
+```https://api.us.cobalt.io/example-endpoint```
+
+You should replace it with:
+
+```https://api.eu.cobalt.io/example-endpoint```
+
+By following the steps outlined above, you can ensure that your API calls correctly target our EU Datacenter. If you encounter any issues or need further assistance, please don't hesitate to contact us: <strong>[integrations@cobalt.io](mailto:integrations@cobalt.io)</strong>.

--- a/versions/v2/content/eudatacenter.md
+++ b/versions/v2/content/eudatacenter.md
@@ -1,18 +1,18 @@
 ---
 weight: 3
-title: EU Datacenter
+title: EU Data center
 ---
 
-# Using the EU Datacenter and the Cobalt API
+# EU Data Center
 <aside class="notice">
-The information provided in this section is specifically tailored for customers who are using our EU Datacenter (app.eu.cobalt.io).
+The information provided in this section is specifically tailored for customers who are using our EU Data center (app.eu.cobalt.io).
 </aside>
 
 ## Introduction
-If you're using our EU Datacenter (app.eu.cobalt.io) and need to call our API, be aware that the base URL for API calls will differ from the examples in our documentation, which use the US version.
+If you're using our EU Data center (app.eu.cobalt.io) and need to call our API, be aware that the base URL for API calls will differ from the examples in our documentation, which use the US version.
 ## Procedure
-1. Identify the Base URL: The base URL for customers using our EU Datacenter is https://api.eu.cobalt.io. This is the URL you should use when making API calls.
-2. Replace the Base URL in Examples: All examples provided in our documentation use the US version of the base URL (https://api.us.cobalt.io). When following these examples, you will need to replace the US base URL with the EU base URL.
+1. Identify the base URL: The base URL for customers using our EU Data center is https://api.eu.cobalt.io. This is the URL you should use when making API calls.
+2. Replace the base URL in examples: All examples provided in our documentation use the US version of the base URL (https://api.us.cobalt.io). When following these examples, you will need to replace the US base URL with the EU base URL.
 3. For example, if an API call in the documentation is shown as:
 
 ```https://api.us.cobalt.io/example-endpoint```
@@ -21,4 +21,4 @@ You should replace it with:
 
 ```https://api.eu.cobalt.io/example-endpoint```
 
-By following the steps outlined above, you can ensure that your API calls correctly target our EU Datacenter. If you encounter any issues or need further assistance, please don't hesitate to contact us: <strong>[integrations@cobalt.io](mailto:integrations@cobalt.io)</strong>.
+By following the steps outlined above, you can ensure that your API calls correctly target our EU Data center. If you encounter any issues or need further assistance, please don't hesitate to contact us: <strong>[integrations@cobalt.io](mailto:integrations@cobalt.io)</strong>.

--- a/versions/v2/content/events.md
+++ b/versions/v2/content/events.md
@@ -8,7 +8,7 @@ title: Events
 ## Get All Events
 
 ```sh
-curl -X GET "https://api.cobalt.io/events" \
+curl -X GET "https://api.us.cobalt.io/events" \
   -H "Accept: application/vnd.cobalt.v2+json" \
   -H "Authorization: Bearer YOUR-PERSONAL-API-TOKEN"
 ```
@@ -63,11 +63,11 @@ This endpoint retrieves a list of all events for your account.
 
 ### HTTP Request
 
-`GET https://api.cobalt.io/events`
+`GET https://api.us.cobalt.io/events`
 
 ### URL Parameters
 
 | Parameter | Default | Description                                                                                              |
 |-----------|---------|----------------------------------------------------------------------------------------------------------|
-| `cursor`  | N/A     | Used for [pagination](./#pagination). Example: `https://api.cobalt.io/events?cursor=a1b2c3d4`            |
-| `limit`   | `10`    | If specified, returns only a specified amount of events. Example: `https://api.cobalt.io/events?limit=5` |
+| `cursor`  | N/A     | Used for [pagination](./#pagination). Example: `https://api.us.cobalt.io/events?cursor=a1b2c3d4`            |
+| `limit`   | `10`    | If specified, returns only a specified amount of events. Example: `https://api.us.cobalt.io/events?limit=5` |

--- a/versions/v2/content/findings.md
+++ b/versions/v2/content/findings.md
@@ -8,7 +8,7 @@ title: Findings
 ## Get All Findings
 
 ```sh
-curl -X GET "https://api.cobalt.io/findings" \
+curl -X GET "https://api.us.cobalt.io/findings" \
   -H "Accept: application/vnd.cobalt.v2+json" \
   -H "Authorization: Bearer YOUR-PERSONAL-API-TOKEN" \
   -H "X-Org-Token: YOUR-V2-ORGANIZATION-TOKEN"
@@ -84,7 +84,7 @@ curl -X GET "https://api.cobalt.io/findings" \
       },
       "links": {
         "ui": {
-          "url": "https://api.cobalt.io/links/eyJ0eXBlIjoic29tZXRoaW5nIiwib3JnU2x1ZyI6ImNvYmFsdCIsInBlbnRlc3RUYWciOiJz="
+          "url": "https://api.us.cobalt.io/links/eyJ0eXBlIjoic29tZXRoaW5nIiwib3JnU2x1ZyI6ImNvYmFsdCIsInBlbnRlc3RUYWciOiJz="
         }
       }
     }
@@ -123,24 +123,24 @@ Cobalt Risk Classification (`severity`, a.k.a. `criticality`):
 
 ### HTTP Request
 
-`GET https://api.cobalt.io/findings`
+`GET https://api.us.cobalt.io/findings`
 
 ### URL Parameters
 
 | Parameter               | Default | Description                                                                                                                                                                                                                                                                                                                                      |
 |-------------------------|---------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `cursor`                | N/A     | Used for [pagination](./#pagination). Example: `https://api.cobalt.io/findings?cursor=a1b2c3d4`                                                                                                                                                                                                                                                  |
-| `limit`                 | `10`    | If specified, returns only a specified amount of findings. Example: `https://api.cobalt.io/findings?limit=5`                                                                                                                                                                                                                                     |
-| `pentest`               | N/A     | If specified, returns findings scoped to this pentest id. Example: `https://api.cobalt.io/findings?pentest=pt_PEtv4dqnwGV2efZhLw3BM5`                                                                                                                                                                                                            |
-| `asset`                 | N/A     | If specified, returns findings scoped to this asset id. Example: `https://api.cobalt.io/findings?asset=as_HcChCMueiPQQgvckmZtRSd`                                                                                                                                                                                                                |
-| `state`                 | N/A     | If specified, returns findings that match `state`. See Response Fields below for example `state` values. Example: `https://api.cobalt.io/findings?state=check_fix`. Returns an empty list if no findings match the `state` filter.                                                                                                               |
-| `severity`              | N/A     | If specified, returns findings that match `severity`. See Response Fields below for example `severity` values. Example: `https://api.cobalt.io/findings?severity=medium`. Returns an empty list if no findings match the `severity` filter.                                                                                                      |
-| `labels_contains_all[]` | N/A     | If specified, returns findings that contain all specified labels. This query parameter can be specified multiple times. Returns an empty list if no matches are found. Example: `https://api.cobalt.io/findings?labels_contains_all[]=Awaiting Feedback&labels_contains_all[]=Retest Blocked`                                                    |
-| `sort`                  | N/A     | If specified, returns findings sorted by one of the chosen parameters: `severity`, `impact`, `state`, `created_at` and `updated_at`. When defined, findings are sorted in ascending order by the sort parameter. To sort in descending order, use a `-` before the sort parameter. Example: `https://api.cobalt.io/findings?sort=-severity`.     |
-| `created_at_lte`        | N/A     | If specified, returns findings where the created_at timestamp is less than or equal to the input timestamp. ISO8601 is the supported input timestamp format. Returns an empty list if no findings match the filter. Example: `https://api.cobalt.io/findings?created_at_lte=2020-02-20T15:28:10.335Z`                                            |
-| `created_at_gte`        | N/A     | If specified, returns findings where the created_at timestamp is greater than or equal to the input timestamp. ISO8601 is the supported input timestamp format. Returns an empty list if no findings match the filter. Example: `https://api.cobalt.io/findings?created_at_gte=2020-02-20T15:28:10.335Z`                                         |
-| `updated_at_lte`        | N/A     | If specified, returns findings where the updated_at timestamp is less than or equal to the input timestamp. ISO8601 is the supported input timestamp format. Returns an empty list if no findings match the filter. Example: `https://api.cobalt.io/findings?updated_at_lte=2020-02-20T15:28:10.335Z`                                            |
-| `updated_at_gte`        | N/A     | If specified, returns findings where the updated_at timestamp is greater than or equal to the input timestamp. ISO8601 is the supported input timestamp format. Returns an empty list if no findings match the filter. Example: `https://api.cobalt.io/findings?updated_at_gte=2020-02-20T15:28:10.335Z`                                         |
+| `cursor`                | N/A     | Used for [pagination](./#pagination). Example: `https://api.us.cobalt.io/findings?cursor=a1b2c3d4`                                                                                                                                                                                                                                                  |
+| `limit`                 | `10`    | If specified, returns only a specified amount of findings. Example: `https://api.us.cobalt.io/findings?limit=5`                                                                                                                                                                                                                                     |
+| `pentest`               | N/A     | If specified, returns findings scoped to this pentest id. Example: `https://api.us.cobalt.io/findings?pentest=pt_PEtv4dqnwGV2efZhLw3BM5`                                                                                                                                                                                                            |
+| `asset`                 | N/A     | If specified, returns findings scoped to this asset id. Example: `https://api.us.cobalt.io/findings?asset=as_HcChCMueiPQQgvckmZtRSd`                                                                                                                                                                                                                |
+| `state`                 | N/A     | If specified, returns findings that match `state`. See Response Fields below for example `state` values. Example: `https://api.us.cobalt.io/findings?state=check_fix`. Returns an empty list if no findings match the `state` filter.                                                                                                               |
+| `severity`              | N/A     | If specified, returns findings that match `severity`. See Response Fields below for example `severity` values. Example: `https://api.us.cobalt.io/findings?severity=medium`. Returns an empty list if no findings match the `severity` filter.                                                                                                      |
+| `labels_contains_all[]` | N/A     | If specified, returns findings that contain all specified labels. This query parameter can be specified multiple times. Returns an empty list if no matches are found. Example: `https://api.us.cobalt.io/findings?labels_contains_all[]=Awaiting Feedback&labels_contains_all[]=Retest Blocked`                                                    |
+| `sort`                  | N/A     | If specified, returns findings sorted by one of the chosen parameters: `severity`, `impact`, `state`, `created_at` and `updated_at`. When defined, findings are sorted in ascending order by the sort parameter. To sort in descending order, use a `-` before the sort parameter. Example: `https://api.us.cobalt.io/findings?sort=-severity`.     |
+| `created_at_lte`        | N/A     | If specified, returns findings where the created_at timestamp is less than or equal to the input timestamp. ISO8601 is the supported input timestamp format. Returns an empty list if no findings match the filter. Example: `https://api.us.cobalt.io/findings?created_at_lte=2020-02-20T15:28:10.335Z`                                            |
+| `created_at_gte`        | N/A     | If specified, returns findings where the created_at timestamp is greater than or equal to the input timestamp. ISO8601 is the supported input timestamp format. Returns an empty list if no findings match the filter. Example: `https://api.us.cobalt.io/findings?created_at_gte=2020-02-20T15:28:10.335Z`                                         |
+| `updated_at_lte`        | N/A     | If specified, returns findings where the updated_at timestamp is less than or equal to the input timestamp. ISO8601 is the supported input timestamp format. Returns an empty list if no findings match the filter. Example: `https://api.us.cobalt.io/findings?updated_at_lte=2020-02-20T15:28:10.335Z`                                            |
+| `updated_at_gte`        | N/A     | If specified, returns findings where the updated_at timestamp is greater than or equal to the input timestamp. ISO8601 is the supported input timestamp format. Returns an empty list if no findings match the filter. Example: `https://api.us.cobalt.io/findings?updated_at_gte=2020-02-20T15:28:10.335Z`                                         |
 
 ### Response Fields
 
@@ -173,7 +173,7 @@ Remember - you can only request findings scoped to the organization specified in
 ## Get a Finding
 
 ```sh
-curl -X GET "https://api.cobalt.io/findings/YOUR-FINDING-IDENTIFIER" \
+curl -X GET "https://api.us.cobalt.io/findings/YOUR-FINDING-IDENTIFIER" \
   -H "Accept: application/vnd.cobalt.v2+json" \
   -H "Authorization: Bearer YOUR-PERSONAL-API-TOKEN" \
   -H "X-Org-Token: YOUR-V2-ORGANIZATION-TOKEN"
@@ -227,7 +227,7 @@ curl -X GET "https://api.cobalt.io/findings/YOUR-FINDING-IDENTIFIER" \
   },
   "links": {
     "ui": {
-      "url": "https://api.cobalt.io/links/eyJ0eXBlIjoic29tZXRoaW5nIiwib3JnU2x1ZyI6ImNvYmFsdCIsInBlbnRlc3RUYWciOiJz="
+      "url": "https://api.us.cobalt.io/links/eyJ0eXBlIjoic29tZXRoaW5nIiwib3JnU2x1ZyI6ImNvYmFsdCIsInBlbnRlc3RUYWciOiJz="
     }
   }
 }
@@ -237,7 +237,7 @@ This endpoint retrieves a specific finding that belong to the organization speci
 
 ### HTTP Request
 
-`GET https://api.cobalt.io/findings/YOUR-FINDING-IDENTIFIER`
+`GET https://api.us.cobalt.io/findings/YOUR-FINDING-IDENTIFIER`
 
 ### Response Fields
 

--- a/versions/v2/content/orgs.md
+++ b/versions/v2/content/orgs.md
@@ -8,7 +8,7 @@ title: Organizations
 ## Get All Organizations
 
 ```sh
-curl -X GET "https://api.cobalt.io/orgs" \
+curl -X GET "https://api.us.cobalt.io/orgs" \
   -H "Accept: application/vnd.cobalt.v2+json" \
   -H "Authorization: Bearer YOUR-PERSONAL-API-TOKEN"
 ```
@@ -26,7 +26,7 @@ curl -X GET "https://api.cobalt.io/orgs" \
       },
       "links": {
         "ui": {
-          "url": "https://api.cobalt.io/links/eyJ0eXBlIjoic29tZXRoaW5nIiwib3JnU2x1ZyI6ImNvYmFsdCIsInBlbnRlc3RUYWciOiJz="
+          "url": "https://api.us.cobalt.io/links/eyJ0eXBlIjoic29tZXRoaW5nIiwib3JnU2x1ZyI6ImNvYmFsdCIsInBlbnRlc3RUYWciOiJz="
         }
       }
     },
@@ -38,7 +38,7 @@ curl -X GET "https://api.cobalt.io/orgs" \
       },
       "links": {
         "ui": {
-          "url": "https://api.cobalt.io/links/eyJ0eXBlIjoic29tZXRoaW5nIiwib3JnU2x1ZyI6ImNvYmFsdCIsInBlbnRlc3RUYWciOiJz="
+          "url": "https://api.us.cobalt.io/links/eyJ0eXBlIjoic29tZXRoaW5nIiwib3JnU2x1ZyI6ImNvYmFsdCIsInBlbnRlc3RUYWciOiJz="
         }
       }
     }
@@ -56,14 +56,14 @@ organization.
 
 ### HTTP Request
 
-`GET https://api.cobalt.io/orgs`
+`GET https://api.us.cobalt.io/orgs`
 
 ### URL Parameters
 
 | Parameter | Default | Description                                                                                                   |
 |-----------|---------|---------------------------------------------------------------------------------------------------------------|
-| `cursor`  | N/A     | Used for [pagination](./#pagination). Example: `https://api.cobalt.io/orgs?cursor=a1b2c3d4`                   |
-| `limit`   | `10`    | If specified, returns only a specified amount of organizations. Example: `https://api.cobalt.io/orgs?limit=5` |
+| `cursor`  | N/A     | Used for [pagination](./#pagination). Example: `https://api.us.cobalt.io/orgs?cursor=a1b2c3d4`                   |
+| `limit`   | `10`    | If specified, returns only a specified amount of organizations. Example: `https://api.us.cobalt.io/orgs?limit=5` |
 
 ### Response Fields
 

--- a/versions/v2/content/pagination.md
+++ b/versions/v2/content/pagination.md
@@ -12,7 +12,7 @@ To paginate append the `next_page` or `prev_page` value to the base API URL.
 For example, if the `next_page` value in a response is `/resource?cursor=a1b2c3d4` you can send the following request
 for the next page.
 
-`GET https://api.cobalt.io/resource?cursor=a1b2c3d4`
+`GET https://api.us.cobalt.io/resource?cursor=a1b2c3d4`
 
 <aside class="notice">
 Remember - there is always a default value for the <code>limit</code> query parameter.

--- a/versions/v2/content/pentests.md
+++ b/versions/v2/content/pentests.md
@@ -8,7 +8,7 @@ title: Pentests
 ## Get All Pentests
 
 ```sh
-curl -X GET "https://api.cobalt.io/pentests" \
+curl -X GET "https://api.us.cobalt.io/pentests" \
   -H "Accept: application/vnd.cobalt.v2+json" \
   -H "Authorization: Bearer YOUR-PERSONAL-API-TOKEN" \
   -H "X-Org-Token: YOUR-V2-ORGANIZATION-TOKEN"
@@ -43,7 +43,7 @@ curl -X GET "https://api.cobalt.io/pentests" \
       },
       "links": {
         "ui": {
-          "url": "https://api.cobalt.io/links/eyJ0eXBlIjoic29tZXRoaW5nIiwib3JnU2x1ZyI6ImNvYmFsdCIsInBlbnRlc3RUYWciOiJz="
+          "url": "https://api.us.cobalt.io/links/eyJ0eXBlIjoic29tZXRoaW5nIiwib3JnU2x1ZyI6ImNvYmFsdCIsInBlbnRlc3RUYWciOiJz="
         }
       }
     }
@@ -59,23 +59,23 @@ This endpoint retrieves a list of all pentests that belong to the organization s
 
 ### HTTP Request
 
-`GET https://api.cobalt.io/pentests`
+`GET https://api.us.cobalt.io/pentests`
 
 ### URL Parameters
 
 | Parameter                      | Default | Description                                                                                                                                                                                                                                                                                                   |
 |--------------------------------|---------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `asset`                        | N/A     | If specified, returns pentests scoped to this asset id. Example: `https://api.cobalt.io/pentests?asset=as_GZgcehapJUNh6mjNuqsE4T` or 404 if asset not found                                                                                                                                                   |
-| `cursor`                       | N/A     | Used for [pagination](./#pagination). Example: `https://api.cobalt.io/pentests?cursor=a1b2c3d4`                                                                                                                                                                                                               |
-| `limit`                        | `10`    | If specified, returns only a specified amount of pentests. Example: `https://api.cobalt.io/pentests?limit=5`                                                                                                                                                                                                  |
-| `sort`                         | N/A     | If specified, returns pentests sorted by one of the chosen properties: `start_date`, or `end_date`. When defined, pentests are sorted in ascending order by the sort property. To sort in descending order, use a `-` before the sort property. Example: `https://api.cobalt.io/pentests?sort=-start_date`.   |
-| `state`                        | N/A     | If specified, returns pentests that match `state`. See Response Fields below for example `state` values. Example: `https://api.cobalt.io/pentests?state=new`. Returns an empty list if no pentests match the `state` filter.                                                                                  |
-| `testing_type`                 | N/A     | If specified, returns pentests that match `testing_type`. See Response Fields below for example `testing_type` values. Example: `https://api.cobalt.io/pentests?testing_type=agile`. Returns an empty list if no pentests match the `testing_type` filter.                                                    |
-| `platform_tags_contains_all[]` | N/A     | If specified, returns pentests that contain all specified platform tags. This query parameter can be specified multiple times. Returns an empty list if no matches are found. Example: `https://api.cobalt.io/pentests?platform_tags_contains_all[]=Kotlin&platform_tags_contains_all[]=AWS`                  |
-| `start_date_lte`               | N/A     | If specified, returns pentests where the start_date is less than or equal to the input date. Input format: `YYYY-MM-DD`. Returns an empty list if no pentests match the filter. Example: `https://api.cobalt.io/pentests?start_date_lte=2021-04-16`                                                           |
-| `start_date_gte`               | N/A     | If specified, returns pentests where the start_date is greater than or equal to the input date. Input format: `YYYY-MM-DD`. Returns an empty list if no pentests match the filter. Example: `https://api.cobalt.io/pentests?start_date_gte=2021-04-16`                                                        |
-| `end_date_lte`                 | N/A     | If specified, returns pentests where the end_date is less than or equal to the input date. Input format: `YYYY-MM-DD`. Returns an empty list if no pentests match the filter. Example: `https://api.cobalt.io/pentests?end_date_lte=2021-04-16`                                                               |
-| `end_date_gte`                 | N/A     | If specified, returns pentests where the end_date is greater than or equal to the input date. Input format: `YYYY-MM-DD`. Returns an empty list if no pentests match the filter. Example: `https://api.cobalt.io/pentests?end_date_gte=2021-04-16`                                                            |
+| `asset`                        | N/A     | If specified, returns pentests scoped to this asset id. Example: `https://api.us.cobalt.io/pentests?asset=as_GZgcehapJUNh6mjNuqsE4T` or 404 if asset not found                                                                                                                                                   |
+| `cursor`                       | N/A     | Used for [pagination](./#pagination). Example: `https://api.us.cobalt.io/pentests?cursor=a1b2c3d4`                                                                                                                                                                                                               |
+| `limit`                        | `10`    | If specified, returns only a specified amount of pentests. Example: `https://api.us.cobalt.io/pentests?limit=5`                                                                                                                                                                                                  |
+| `sort`                         | N/A     | If specified, returns pentests sorted by one of the chosen properties: `start_date`, or `end_date`. When defined, pentests are sorted in ascending order by the sort property. To sort in descending order, use a `-` before the sort property. Example: `https://api.us.cobalt.io/pentests?sort=-start_date`.   |
+| `state`                        | N/A     | If specified, returns pentests that match `state`. See Response Fields below for example `state` values. Example: `https://api.us.cobalt.io/pentests?state=new`. Returns an empty list if no pentests match the `state` filter.                                                                                  |
+| `testing_type`                 | N/A     | If specified, returns pentests that match `testing_type`. See Response Fields below for example `testing_type` values. Example: `https://api.us.cobalt.io/pentests?testing_type=agile`. Returns an empty list if no pentests match the `testing_type` filter.                                                    |
+| `platform_tags_contains_all[]` | N/A     | If specified, returns pentests that contain all specified platform tags. This query parameter can be specified multiple times. Returns an empty list if no matches are found. Example: `https://api.us.cobalt.io/pentests?platform_tags_contains_all[]=Kotlin&platform_tags_contains_all[]=AWS`                  |
+| `start_date_lte`               | N/A     | If specified, returns pentests where the start_date is less than or equal to the input date. Input format: `YYYY-MM-DD`. Returns an empty list if no pentests match the filter. Example: `https://api.us.cobalt.io/pentests?start_date_lte=2021-04-16`                                                           |
+| `start_date_gte`               | N/A     | If specified, returns pentests where the start_date is greater than or equal to the input date. Input format: `YYYY-MM-DD`. Returns an empty list if no pentests match the filter. Example: `https://api.us.cobalt.io/pentests?start_date_gte=2021-04-16`                                                        |
+| `end_date_lte`                 | N/A     | If specified, returns pentests where the end_date is less than or equal to the input date. Input format: `YYYY-MM-DD`. Returns an empty list if no pentests match the filter. Example: `https://api.us.cobalt.io/pentests?end_date_lte=2021-04-16`                                                               |
+| `end_date_gte`                 | N/A     | If specified, returns pentests where the end_date is greater than or equal to the input date. Input format: `YYYY-MM-DD`. Returns an empty list if no pentests match the filter. Example: `https://api.us.cobalt.io/pentests?end_date_gte=2021-04-16`                                                            |
 
 ### Response Fields
 
@@ -101,7 +101,7 @@ Remember - you can only request pentests scoped to the organization specified in
 ## Get a Pentest
 
 ```sh
-curl -X GET "https://api.cobalt.io/pentests/YOUR-PENTEST-IDENTIFIER" \
+curl -X GET "https://api.us.cobalt.io/pentests/YOUR-PENTEST-IDENTIFIER" \
   -H "Accept: application/vnd.cobalt.v2+json" \
   -H "Authorization: Bearer YOUR-PERSONAL-API-TOKEN" \
   -H "X-Org-Token: YOUR-V2-ORGANIZATION-TOKEN"
@@ -135,7 +135,7 @@ curl -X GET "https://api.cobalt.io/pentests/YOUR-PENTEST-IDENTIFIER" \
     },
     "links": {
       "ui": {
-        "url": "https://api.cobalt.io/links/eyJ0eXBlIjoic29tZXRoaW5nIiwib3JnU2x1ZyI6ImNvYmFsdCIsInBlbnRlc3RUYWciOiJz="
+        "url": "https://api.us.cobalt.io/links/eyJ0eXBlIjoic29tZXRoaW5nIiwib3JnU2x1ZyI6ImNvYmFsdCIsInBlbnRlc3RUYWciOiJz="
       }
     }
   }
@@ -146,7 +146,7 @@ This endpoint retrieves a specific pentest that belongs to the organization spec
 
 ### HTTP Request
 
-`GET https://api.cobalt.io/pentests/YOUR-PENTEST-IDENTIFIER-HERE`
+`GET https://api.us.cobalt.io/pentests/YOUR-PENTEST-IDENTIFIER-HERE`
 
 ### Response Fields
 
@@ -172,7 +172,7 @@ Remember - you can only request a pentest scoped to the organization specified i
 ## Get a Pentest Report
 
 ```sh
-curl -X GET "https://api.cobalt.io/pentests/YOUR-PENTEST-IDENTIFIER/report" \
+curl -X GET "https://api.us.cobalt.io/pentests/YOUR-PENTEST-IDENTIFIER/report" \
   -H "Accept: application/vnd.cobalt.v2+json" \
   -H "Authorization: Bearer YOUR-PERSONAL-API-TOKEN" \
   -H "X-Org-Token: YOUR-V2-ORGANIZATION-TOKEN"
@@ -268,7 +268,7 @@ curl -X GET "https://api.cobalt.io/pentests/YOUR-PENTEST-IDENTIFIER/report" \
     },
     "links": {
       "ui": {
-        "url": "https://api.cobalt.io/links/eyJ0eXBlIjoic29tZXRoaW5nIiwib3JnU2x1ZyI6ImNvYmFsdCIsInBlbnRlc3RUYWciOiJz="
+        "url": "https://api.us.cobalt.io/links/eyJ0eXBlIjoic29tZXRoaW5nIiwib3JnU2x1ZyI6ImNvYmFsdCIsInBlbnRlc3RUYWciOiJz="
       }
     }
   }
@@ -290,7 +290,7 @@ issue.
 
 ### HTTP Request
 
-`GET https://api.cobalt.io/pentests/YOUR-PENTEST-IDENTIFIER-HERE/report`
+`GET https://api.us.cobalt.io/pentests/YOUR-PENTEST-IDENTIFIER-HERE/report`
 
 ### Response Fields
 
@@ -344,7 +344,7 @@ Remember - you can only request the report for a pentest scoped to the organizat
 ## Duplicate a Pentest
 
 ```sh
-curl -X POST "https://api.cobalt.io/pentests/YOUR-PENTEST-IDENTIFIER/duplicate" \
+curl -X POST "https://api.us.cobalt.io/pentests/YOUR-PENTEST-IDENTIFIER/duplicate" \
   -H "Accept: application/vnd.cobalt.v2+json" \
   -H "Content-Type: application/vnd.cobalt.v2+json" \
   -H "Idempotency-Key: A-UNIQUE-IDENTIFIER-TO-PREVENT-UNINTENTIONAL-DUPLICATION" \
@@ -360,7 +360,7 @@ The new pentest will be in **Draft state** and will have the same brief as the p
 
 ### HTTP Request
 
-`POST https://api.cobalt.io/pentests/YOUR-PENTEST-IDENTIFIER-HERE/duplicate`
+`POST https://api.us.cobalt.io/pentests/YOUR-PENTEST-IDENTIFIER-HERE/duplicate`
 
 ### Response
 
@@ -374,7 +374,7 @@ Remember - you can only duplicate a pentest within the organization specified in
 ## Create a Pentest
 
 ```sh
-curl -X POST "https://api.cobalt.io/pentests" \
+curl -X POST "https://api.us.cobalt.io/pentests" \
   -H "Accept: application/vnd.cobalt.v2+json" \
   -H "Authorization: Bearer YOUR-PERSONAL-API-TOKEN" \
   -H "Content-Type: application/vnd.cobalt.v2+json" \
@@ -408,7 +408,7 @@ organization specified in the `X-Org-Token` header. The pentest will be in the *
 
 ### HTTP Request
 
-`POST https://api.cobalt.io/pentests`
+`POST https://api.us.cobalt.io/pentests`
 
 ### Body
 
@@ -456,7 +456,7 @@ Remember - you can only create a pentest within the organization specified in th
 ## Update a Pentest
 
 ```sh
-curl -X PUT "https://api.cobalt.io/pentests/YOUR-PENTEST-IDENTIFIER" \
+curl -X PUT "https://api.us.cobalt.io/pentests/YOUR-PENTEST-IDENTIFIER" \
   -H "Accept: application/vnd.cobalt.v2+json" \
   -H "Authorization: Bearer YOUR-PERSONAL-API-TOKEN" \
   -H "Content-Type: application/vnd.cobalt.v2+json" \
@@ -488,7 +488,7 @@ This endpoint updates a pentest from the information provided.
 
 ### HTTP Request
 
-`PUT https://api.cobalt.io/pentests/YOUR-PENTEST-IDENTIFIER`
+`PUT https://api.us.cobalt.io/pentests/YOUR-PENTEST-IDENTIFIER`
 
 ### Body
 
@@ -535,7 +535,7 @@ Remember - you can only update a pentest within the organization specified in th
 ## Delete a Pentest
 
 ```sh
-curl -X DELETE 'https://api.cobalt.io/pentests/YOUR-PENTEST-IDENTIFIER' \
+curl -X DELETE 'https://api.us.cobalt.io/pentests/YOUR-PENTEST-IDENTIFIER' \
   -H 'Accept: application/vnd.cobalt.v2+json' \
   -H 'Authorization: Bearer YOUR-PERSONAL-API-TOKEN' \
   -H 'X-Org-Token: YOUR-V2-ORGANIZATION-TOKEN'
@@ -548,7 +548,7 @@ Note that you **can** only delete a pentest when it is in draft or review state.
 
 ### HTTP Request
 
-`DELETE https://api.cobalt.io/pentests/YOUR-PENTEST-IDENTIFIER`
+`DELETE https://api.us.cobalt.io/pentests/YOUR-PENTEST-IDENTIFIER`
 
 ### Response
 

--- a/versions/v2/content/tokens.md
+++ b/versions/v2/content/tokens.md
@@ -8,7 +8,7 @@ title: Tokens
 ## Get All Tokens
 
 ```sh
-curl -X GET "https://api.cobalt.io/tokens" \
+curl -X GET "https://api.us.cobalt.io/tokens" \
   -H "Accept: application/vnd.cobalt.v2+json" \
   -H "Authorization: Bearer YOUR-PERSONAL-API-TOKEN"
 ```
@@ -38,14 +38,14 @@ This endpoint retrieves a list of all tokens that belong to you.
 
 ### HTTP Request
 
-`GET https://api.cobalt.io/tokens`
+`GET https://api.us.cobalt.io/tokens`
 
 ### URL Parameters
 
 | Parameter | Default | Description                                                                                              |
 |-----------|---------|----------------------------------------------------------------------------------------------------------|
-| `cursor`  | N/A     | Used for [pagination](./#pagination). Example: `https://api.cobalt.io/tokens?cursor=a1b2c3d4`            |
-| `limit`   | `10`    | If specified, returns only a specified amount of tokens. Example: `https://api.cobalt.io/tokens?limit=5` |
+| `cursor`  | N/A     | Used for [pagination](./#pagination). Example: `https://api.us.cobalt.io/tokens?cursor=a1b2c3d4`            |
+| `limit`   | `10`    | If specified, returns only a specified amount of tokens. Example: `https://api.us.cobalt.io/tokens?limit=5` |
 
 ### Response Fields
 
@@ -59,7 +59,7 @@ This endpoint retrieves a list of all tokens that belong to you.
 ## Refresh Token
 
 ```sh
-curl -X POST "https://api.cobalt.io/tokens/YOUR-TOKEN-ID/refresh" \
+curl -X POST "https://api.us.cobalt.io/tokens/YOUR-TOKEN-ID/refresh" \
   -H "Accept: application/vnd.cobalt.v2+json" \
   -H "Authorization: Bearer YOUR-PERSONAL-API-TOKEN"
 ```
@@ -93,7 +93,7 @@ revoke the old token you've forgotten, and generate a new token.
 
 ### HTTP Request
 
-`POST https://api.cobalt.io/tokens/YOUR-TOKEN-ID/refresh`
+`POST https://api.us.cobalt.io/tokens/YOUR-TOKEN-ID/refresh`
 
 ### Response Fields
 

--- a/versions/v2/content/update-finding-state.md
+++ b/versions/v2/content/update-finding-state.md
@@ -6,7 +6,7 @@ title: Update Finding State
 ## View Available Finding States
 
 ```sh
-curl -X GET "https://api.cobalt.io/findings/YOUR-FINDING-ID/possible_states" \
+curl -X GET "https://api.us.cobalt.io/findings/YOUR-FINDING-ID/possible_states" \
   -H "Accept: application/vnd.cobalt.v2+json" \
   -H "Authorization: Bearer YOUR-PERSONAL-API-TOKEN" \
   -H "X-Org-Token: YOUR-V2-ORGANIZATION-TOKEN"
@@ -32,7 +32,7 @@ This endpoint retrieves the current state of a finding as well as possible next 
 
 ### HTTP Request
 
-`GET https://api.cobalt.io/findings/YOUR-FINDING-ID/possible_states`
+`GET https://api.us.cobalt.io/findings/YOUR-FINDING-ID/possible_states`
 
 ### URL Parameters
 
@@ -60,7 +60,7 @@ This endpoint retrieves the current state of a finding as well as possible next 
 ## Update Finding State
 
 ```sh
-curl -X PATCH "https://api.cobalt.io/findings/YOUR-FINDING-ID" \
+curl -X PATCH "https://api.us.cobalt.io/findings/YOUR-FINDING-ID" \
   -H "Accept: application/vnd.cobalt.v2+json" \
   -H 'Content-Type: application/vnd.cobalt.v2+json' \
   -H "Idempotency-Key: A-UNIQUE-IDENTIFIER-TO-PREVENT-UNINTENTIONAL-DUPLICATION" \
@@ -75,7 +75,7 @@ This endpoint updates the current state of a finding.
 
 ### HTTP Request
 
-`PATCH https://api.cobalt.io/findings/YOUR-FINDING-ID`
+`PATCH https://api.us.cobalt.io/findings/YOUR-FINDING-ID`
 
 ### URL Parameters
 

--- a/versions/v2/content/webhooks.md
+++ b/versions/v2/content/webhooks.md
@@ -12,7 +12,7 @@ You can also manage your webhooks within the Integrations Hub in the Cobalt Plat
 ## Get all webhooks
 
 ```sh
-curl -X GET "https://api.cobalt.io/webhooks" \
+curl -X GET "https://api.us.cobalt.io/webhooks" \
   -H "Accept: application/vnd.cobalt.v2+json" \
   -H "Authorization: Bearer YOUR-PERSONAL-API-TOKEN" \
   -H "X-Org-Token: YOUR-V2-ORGANIZATION-TOKEN"
@@ -53,14 +53,14 @@ This endpoint retrieves a list of all webhooks that belong to your organization.
 
 ### HTTP Request
 
-`GET https://api.cobalt.io/webhooks`
+`GET https://api.us.cobalt.io/webhooks`
 
 ### URL Parameters
 
 | Parameter | Default | Description                                                                                                  |
 |-----------|---------|--------------------------------------------------------------------------------------------------------------|
-| `cursor`  | N/A     | Used for [pagination](./#pagination). Example: `https://api.cobalt.io/webhooks?cursor=a1b2c3d4`              |
-| `limit`   | `10`    | If specified, returns only a specified amount of webhooks. Example: `https://api.cobalt.io/webhooks?limit=5` |
+| `cursor`  | N/A     | Used for [pagination](./#pagination). Example: `https://api.us.cobalt.io/webhooks?cursor=a1b2c3d4`              |
+| `limit`   | `10`    | If specified, returns only a specified amount of webhooks. Example: `https://api.us.cobalt.io/webhooks?limit=5` |
 
 ### Response Fields
 
@@ -77,7 +77,7 @@ This endpoint retrieves a list of all webhooks that belong to your organization.
 ## Get a webhook
 
 ```sh
-curl -X GET "https://api.cobalt.io/webhooks/YOUR-WEBHOOK-IDENTIFIER" \
+curl -X GET "https://api.us.cobalt.io/webhooks/YOUR-WEBHOOK-IDENTIFIER" \
   -H "Accept: application/vnd.cobalt.v2+json" \
   -H "Authorization: Bearer YOUR-PERSONAL-API-TOKEN" \
   -H "X-Org-Token: YOUR-V2-ORGANIZATION-TOKEN"
@@ -110,7 +110,7 @@ This endpoint retrieves a specific webhook belonging to your organization.
 
 ### HTTP Request
 
-`GET https://api.cobalt.io/webhooks/YOUR-WEBHOOK-IDENTIFIER`
+`GET https://api.us.cobalt.io/webhooks/YOUR-WEBHOOK-IDENTIFIER`
 
 ### Response Fields
 
@@ -131,7 +131,7 @@ Remember - you can only request a webhook scoped to the organization specified i
 ## Create a webhook
 
 ```sh
-curl -X POST "https://api.cobalt.io/webhooks" \
+curl -X POST "https://api.us.cobalt.io/webhooks" \
   -H 'Accept: application/vnd.cobalt.v2+json' \
   -H 'Authorization: Bearer YOUR-PERSONAL-API-TOKEN' \
   -H 'Content-Type: application/vnd.cobalt.v2+json' \
@@ -159,7 +159,7 @@ for example, 200, 201, 204, etc. For details on test events, see the [Webhook Ev
 
 ### HTTP Request
 
-`POST https://api.cobalt.io/webhooks`
+`POST https://api.us.cobalt.io/webhooks`
 
 ### Body
 
@@ -187,7 +187,7 @@ Remember - you can only create a webhook within the organization specified in th
 ## Update a webhook
 
 ```sh
-curl -X PATCH 'https://api.cobalt.io/webhooks/YOUR-WEBHOOK-IDENTIFIER' \
+curl -X PATCH 'https://api.us.cobalt.io/webhooks/YOUR-WEBHOOK-IDENTIFIER' \
   -H 'Accept: application/vnd.cobalt.v2+json' \
   -H 'Authorization: Bearer YOUR-PERSONAL-API-TOKEN' \
   -H 'Content-Type: application/vnd.cobalt.v2+json' \
@@ -210,7 +210,7 @@ This endpoint updates a webhook belonging to your organization.
 
 ### HTTP Request
 
-`PATCH https://api.cobalt.io/webhooks/YOUR-WEBHOOK-IDENTIFIER`
+`PATCH https://api.us.cobalt.io/webhooks/YOUR-WEBHOOK-IDENTIFIER`
 
 ### Body
 
@@ -243,7 +243,7 @@ Remember - you can only update a webhook within the organization specified in th
 ## Delete a webhook
 
 ```sh
-curl -X DELETE 'https://api.cobalt.io/webhooks/YOUR-WEBHOOK-IDENTIFIER' \
+curl -X DELETE 'https://api.us.cobalt.io/webhooks/YOUR-WEBHOOK-IDENTIFIER' \
   -H 'Accept: application/vnd.cobalt.v2+json' \
   -H 'Authorization: Bearer YOUR-PERSONAL-API-TOKEN' \
   -H 'Content-Type: application/vnd.cobalt.v2+json' \
@@ -256,7 +256,7 @@ This endpoint deletes a webhook belonging to your organization.
 
 ### HTTP Request
 
-`DELETE https://api.cobalt.io/webhooks/YOUR-WEBHOOK-IDENTIFIER`
+`DELETE https://api.us.cobalt.io/webhooks/YOUR-WEBHOOK-IDENTIFIER`
 
 ### Response
 


### PR DESCRIPTION
Add EUDC docs.

The md check fails because it validates the existence of the base URLs and they are no valid endpoints.
```
[✖] https://api.eu.cobalt.io → Status: 404
[✖] https://api.us.cobalt.io/ → Status: 404
```