### PR TITLE
[NO-TICKET]: fix `Update Finding State` param docs

### DIFF
--- a/versions/v2/content/update-finding-state.md
+++ b/versions/v2/content/update-finding-state.md
@@ -36,9 +36,9 @@ This endpoint retrieves the current state of a finding as well as possible next 
 
 ### URL Parameters
 
-| Parameter         | Description                                                  |
-|-------------------|--------------------------------------------------------------|
-| `YOUR-FINDING-ID` | A unique ID representing the organization. Starts with `vl_` |
+| Parameter         | Description                                             |
+|-------------------|---------------------------------------------------------|
+| `YOUR-FINDING-ID` | A unique ID representing the finding. Starts with `vl_` |
 
 ### Response Fields
 
@@ -62,7 +62,7 @@ This endpoint retrieves the current state of a finding as well as possible next 
 ```sh
 curl -X PATCH "https://api.us.cobalt.io/findings/YOUR-FINDING-ID" \
   -H "Accept: application/vnd.cobalt.v2+json" \
-  -H 'Content-Type: application/vnd.cobalt.v2+json' \
+  -H "Content-Type: application/vnd.cobalt.v2+json" \
   -H "Idempotency-Key: A-UNIQUE-IDENTIFIER-TO-PREVENT-UNINTENTIONAL-DUPLICATION" \
   -H "Authorization: Bearer YOUR-PERSONAL-API-TOKEN" \
   -H "X-Org-Token: YOUR-V2-ORGANIZATION-TOKEN" \
@@ -79,12 +79,12 @@ This endpoint updates the current state of a finding.
 
 ### URL Parameters
 
-| Parameter         | Description                                                  |
-|-------------------|--------------------------------------------------------------|
-| `YOUR-FINDING-ID` | A unique ID representing the organization. Starts with `vl_` |
+| Parameter         | Description                                             |
+|-------------------|---------------------------------------------------------|
+| `YOUR-FINDING-ID` | A unique ID representing the finding. Starts with `vl_` |
 
 ### Body
 
 | Field   | Description                                                                  |
 |---------|------------------------------------------------------------------------------|
-| `state` | The desired next state of the finding. Should be one of the possible states. |
+| `state` | The desired next state of the finding. Should be one of the possible [states](./#states). |


### PR DESCRIPTION
### Fixed: 
 - change `organization` to `finding` in params doc.

Before:

<img width="600" alt="Screenshot 2024-03-27 at 14 51 13" src="https://github.com/cobalthq/cobalt-api-docs/assets/1405703/a5f9e8b6-17dd-430a-aa9a-4f9425335b90">
<img width="654" alt="Screenshot 2024-03-27 at 14 51 18" src="https://github.com/cobalthq/cobalt-api-docs/assets/1405703/68ed70f5-1131-451f-a788-82688ab490b5">


After:
<img width="524" alt="Screenshot 2024-03-27 at 14 51 40" src="https://github.com/cobalthq/cobalt-api-docs/assets/1405703/b9692fdd-75fc-47f7-8c56-4bf81194b2ae">
<img width="529" alt="Screenshot 2024-03-27 at 14 51 45" src="https://github.com/cobalthq/cobalt-api-docs/assets/1405703/b727010f-f82e-4937-9466-49ecaaeab518">


### Changed:
 - Prefer `"` over `'` in the `curl` commands.

### Added:
 - link from the params doc to the `states`

https://github.com/cobalthq/cobalt-api-docs/assets/1405703/adae15dc-8eea-4fd0-a7e6-628a3ea188ac



