### PR TITLE
Add DAST targets

### DIFF
--- a/versions/v2/content/dast-targets.md
+++ b/versions/v2/content/dast-targets.md
@@ -91,5 +91,5 @@ This endpoint retrieves a specific DAST Target that belongs to the organization 
 |-----------------|-------------------------------------------------------------------------------------|
 | `id`      | A unique ID representing the DAST target. Starts with `dt_`                             |
 | `name`    | The name of the returned DAST target.                                                  |
-| `url`     | The URL of the returns DAST target              |
+| `url`     | The URL of the returned DAST target              |
 | `enabled` | A boolean flag specifying if the DAST target is enabled                                |

--- a/versions/v2/content/dast-targets.md
+++ b/versions/v2/content/dast-targets.md
@@ -1,0 +1,95 @@
+---
+weight: 9
+title: DAST Targets
+---
+
+# DAST Targets
+
+## Get All DAST Targets
+
+```sh
+curl -X GET "https://api.us.cobalt.io/dast/targets" \
+  -H "Accept: application/vnd.cobalt.v2+json" \
+  -H "Authorization: Bearer YOUR-PERSONAL-API-TOKEN" \
+  -H "X-Org-Token: YOUR-V2-ORGANIZATION-TOKEN"
+```
+
+> The above command returns JSON structured like this:
+
+```json
+{
+  "pagination": {
+    "next_page": "/resource?cursor=123asdzxc",
+    "prev_page": "/resource?cursor=123asdzxc"
+  },
+  "data": [
+    {
+      "resource": {
+        "id": "dt_GZgcehapJUNh6mjNuqsE4T",
+        "name": "My DAST Target",
+        "url": "https://myapp.local",
+        "enabled": true
+      }
+    }
+  ]
+}
+```
+
+This endpoint retrieves a list of all DAST Targets for the organization.
+
+### HTTP Request
+
+`GET https://api.us.cobalt.io/dast/targets`
+
+### URL Parameters
+
+| Parameter                      | Default | Description                                                                                                                                                                                                                                                                                                   |
+|--------------------------------|---------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `cursor`                       | N/A     | Used for [pagination](./#pagination). Example: `https://api.us.cobalt.io/dast/targets?cursor=a1b2c3d4`                                                                                                                                                                                                               |
+| `limit`                        | `10`    | If specified, returns only a specified amount of targets. Example: `https://api.us.cobalt.io/dast/targets?limit=5`                                                                                                                                                                              |
+
+### Response Fields
+
+| Field           | Description                                                                         |
+|-----------------|-------------------------------------------------------------------------------------|
+| `id`      | A unique ID representing the DAST target. Starts with `dt_`                             |
+| `name`    | The name of the returned DAST target.                                                  |
+| `url`     | The URL of the returns DAST target              |
+| `enabled` | A boolean flag specifying if the DAST target is enabled                                |
+
+## Get a DAST Target
+
+```sh
+curl -X GET "https://api.us.cobalt.io/dast/targets/YOUR-DAST-TARGET-IDENTIFIER" \
+  -H "Accept: application/vnd.cobalt.v2+json" \
+  -H "Authorization: Bearer YOUR-PERSONAL-API-TOKEN" \
+  -H "X-Org-Token: YOUR-V2-ORGANIZATION-TOKEN"
+```
+
+> The above command returns JSON structured like this:
+
+```json
+{
+  "resource": {
+    "id": "dt_GZgcehapJUNh6mjNuqsE4T",
+    "name": "My DAST Target",
+    "url": "https://myapp.local",
+    "enabled": true
+  }
+}
+```
+
+This endpoint retrieves a specific DAST Target that belongs to the organization specified in the `X-Org-Token` header.
+
+### HTTP Request
+
+`GET https://api.us.cobalt.io/dast/targets/YOUR-DAST-TARGET-IDENTIFIER`
+
+### Response Fields
+
+| Field           | Description                                                                         |
+|-----------------|-------------------------------------------------------------------------------------|
+| `id`      | A unique ID representing the DAST target. Starts with `dt_`                             |
+| `name`    | The name of the returned DAST target.                                                  |
+| `url`     | The URL of the returns DAST target              |
+| `enabled` | A boolean flag specifying if the DAST target is enabled                                |

--- a/versions/v2/content/dast-targets.md
+++ b/versions/v2/content/dast-targets.md
@@ -54,7 +54,7 @@ This endpoint retrieves a list of all DAST Targets that belong to the organizati
 |-----------------|-------------------------------------------------------------------------------------|
 | `id`      | A unique ID representing the DAST target. Starts with `dt_`                             |
 | `name`    | The name of the returned DAST target.                                                  |
-| `url`     | The URL of the returns DAST target              |
+| `url`     | The URL of the returned DAST target              |
 | `enabled` | A boolean flag specifying if the DAST target is enabled                                |
 
 ## Get a DAST Target

--- a/versions/v2/content/dast-targets.md
+++ b/versions/v2/content/dast-targets.md
@@ -1,5 +1,5 @@
 ---
-weight: 9
+weight: 15
 title: DAST Targets
 ---
 

--- a/versions/v2/content/dast-targets.md
+++ b/versions/v2/content/dast-targets.md
@@ -35,7 +35,7 @@ curl -X GET "https://api.us.cobalt.io/dast/targets" \
 }
 ```
 
-This endpoint retrieves a list of all DAST Targets for the organization.
+This endpoint retrieves a list of all DAST Targets that belong to the organization specified in the `X-Org-Token` header.
 
 ### HTTP Request
 
@@ -43,10 +43,10 @@ This endpoint retrieves a list of all DAST Targets for the organization.
 
 ### URL Parameters
 
-| Parameter                      | Default | Description                                                                                                                                                                                                                                                                                                   |
-|--------------------------------|---------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `cursor`                       | N/A     | Used for [pagination](./#pagination). Example: `https://api.us.cobalt.io/dast/targets?cursor=a1b2c3d4`                                                                                                                                                                                                               |
-| `limit`                        | `10`    | If specified, returns only a specified amount of targets. Example: `https://api.us.cobalt.io/dast/targets?limit=5`                                                                                                                                                                              |
+| Parameter          | Default | Description  |
+|--------------------|---------|-----------------|
+| `cursor`      | N/A     | Used for [pagination](./#pagination). Example: `https://api.us.cobalt.io/dast/targets?cursor=a1b2c3d4` |
+| `limit`       | `10`    | If specified, returns only a specified amount of targets. Example: `https://api.us.cobalt.io/dast/targets?limit=5`|
 
 ### Response Fields
 

--- a/versions/v2/content/errors.md
+++ b/versions/v2/content/errors.md
@@ -1,5 +1,5 @@
 ---
-weight: 16
+weight: 80
 title: Errors
 ---
 

--- a/versions/v2/content/events.md
+++ b/versions/v2/content/events.md
@@ -1,5 +1,5 @@
 ---
-weight: 10
+weight: 20
 title: Events
 ---
 

--- a/versions/v2/content/idempotency.md
+++ b/versions/v2/content/idempotency.md
@@ -1,5 +1,5 @@
 ---
-weight: 14
+weight: 60
 title: Idempotency
 ---
 

--- a/versions/v2/content/pagination.md
+++ b/versions/v2/content/pagination.md
@@ -1,5 +1,5 @@
 ---
-weight: 13
+weight: 50
 title: Pagination
 ---
 

--- a/versions/v2/content/partner-integrations.md
+++ b/versions/v2/content/partner-integrations.md
@@ -1,5 +1,5 @@
 ---
-weight: 17
+weight: 90
 title: Partner Integrations
 ---
 

--- a/versions/v2/content/rate-limits.md
+++ b/versions/v2/content/rate-limits.md
@@ -1,5 +1,5 @@
 ---
-weight: 15
+weight: 70
 title: Rate Limits
 ---
 

--- a/versions/v2/content/tokens.md
+++ b/versions/v2/content/tokens.md
@@ -1,5 +1,5 @@
 ---
-weight: 10
+weight: 30
 title: Tokens
 ---
 

--- a/versions/v2/content/webhooks.md
+++ b/versions/v2/content/webhooks.md
@@ -1,5 +1,5 @@
 ---
-weight: 11
+weight: 40
 title: Webhooks
 ---
 


### PR DESCRIPTION
https://zombie.atlassian.net/browse/FX-4416

## Changes
- I tried to mimic the pentests page while coping DAST Target info form https://api.us.cobalt.io/cobalt-api-docs/webjars/swagger-ui/index.html#/DAST%20Targets/getV2DastTarget
- I spaced out the page weights a bit to make it easier to insert more pages in the middle later.

## Screenshots
|   change    |    before      |     after    |
|--------|--------|--------|
|   Side nav    |   ![Screenshot 2024-07-01 at 11 24 37](https://github.com/cobalthq/cobalt-api-docs/assets/76952596/5ee1f481-001a-4da7-8328-4cba6867575e)      |    ![Screenshot 2024-07-01 at 11 24 56](https://github.com/cobalthq/cobalt-api-docs/assets/76952596/200cf1f6-86c2-45f3-8634-b4479fb50e50)    |
|   New menu    |         |    ![Screenshot 2024-07-01 at 11 28 43](https://github.com/cobalthq/cobalt-api-docs/assets/76952596/97f8b6e2-6e47-4617-83d3-d8be36802fbe)    |