### PR TITLE
[FX-4415] Add filter by `external_id` and `ticketing_system`

### DIFF
--- a/versions/v2/content/external-ticket-references.md
+++ b/versions/v2/content/external-ticket-references.md
@@ -60,7 +60,7 @@ curl --location 'https://api.us.cobalt.io/external_ticket_references/search' \
 This endpoint retrieves a list of all external ticket references that belong to the organization specified in the `X-Org-Token`
 header.
 
-If you want to filter the search results based on a subset of findings, you can use the `findings` property in the
+> If you want to filter the search results based on a subset of findings, you can use the `findings` property in the
 request body.
 
 ```sh
@@ -71,7 +71,7 @@ curl --location 'https://api.us.cobalt.io/external_ticket_references/search' \
   --data '{"findings":[{"id":"vl_JTovzf8AW1afCRpKJejse3"},{"id":"dfi_2bZrrKE3Hay7oLrbNUponW"}]}'
 ```
 
-You can filter the external ticket references by a particular ticketing system using the `ticketing_system` property.
+> You can filter the external ticket references by a particular ticketing system using the `ticketing_system` property.
 
 ```sh
 curl --location 'https://api.us.cobalt.io/external_ticket_references/search' \
@@ -81,7 +81,7 @@ curl --location 'https://api.us.cobalt.io/external_ticket_references/search' \
   --data '{"ticketing_system":"azure_devops_boards"}'
 ```
 
-The `external_id` property can filter the external ticket reference by its identifier in the external ticketing system.
+> The `external_id` property can filter the external ticket reference by its identifier in the external ticketing system.
 
 ```sh
 curl --location 'https://api.us.cobalt.io/external_ticket_references/search' \

--- a/versions/v2/content/external-ticket-references.md
+++ b/versions/v2/content/external-ticket-references.md
@@ -71,19 +71,46 @@ curl --location 'https://api.us.cobalt.io/external_ticket_references/search' \
   --data '{"findings":[{"id":"vl_JTovzf8AW1afCRpKJejse3"},{"id":"dfi_2bZrrKE3Hay7oLrbNUponW"}]}'
 ```
 
+You can filter the external ticket references by a particular ticketing system using the `ticketing_system` property.
+
+```sh
+curl --location 'https://api.us.cobalt.io/external_ticket_references/search' \
+  -H "Accept: application/vnd.cobalt.v2+json" \
+  -H "Authorization: Bearer YOUR-PERSONAL-API-TOKEN" \
+  -H "X-Org-Token: YOUR-V2-ORGANIZATION-TOKEN"
+  --data '{"ticketing_system":"azure_devops_boards"}'
+```
+
+The `external_id` property can filter the external ticket reference by its identifier in the external ticketing system.
+
+```sh
+curl --location 'https://api.us.cobalt.io/external_ticket_references/search' \
+  -H "Accept: application/vnd.cobalt.v2+json" \
+  -H "Authorization: Bearer YOUR-PERSONAL-API-TOKEN" \
+  -H "X-Org-Token: YOUR-V2-ORGANIZATION-TOKEN"
+  --data '{"external_id":"8"}'
+```
+
 ### HTTP Request
 
 `POST https://api.us.cobalt.io/external_ticket_references/search`
 
 ### Request Body
 
-| Field      | Description                                                                                                                                     |
-| ---------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
-| `findings` | An array of finding ID `object`s to filter the search. For example, `[{"id":"vl_JTovzf8AW1afCRpKJejse3"},{"id":"dfi_2bZrrKE3Hay7oLrbNUponW"}]`. |
+| Field              | Description                                                                                                                                     |
+| ------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| `findings`         | An array of finding ID `object`s to filter the search. For example, `[{"id":"vl_JTovzf8AW1afCRpKJejse3"},{"id":"dfi_2bZrrKE3Hay7oLrbNUponW"}]`. |
+| `ticketing_system` | One of the [supported ticketing systems](#supported-ticketing-systems).                                                                         |
+| `external_id`      | The external ticket's identifier in the external ticketing system.                                                                              |
 
 <aside class="notice">
 Remember - if the <code>findings</code> property is defined in the search request body, but is empty, the search result
 will always be empty.
+</aside>
+
+<aside class="notice">
+Remember - when filtering by the <code>external_id</code>, the string match must be a case-sensitive, full match.
+Partial matches, regexes, and <code>LIKE</code> query wildcards are not supported.
 </aside>
 
 ## Create an External Ticket Reference
@@ -123,7 +150,7 @@ along with the created external ticket reference information.
 | Field              | Description                                                                   |
 | ------------------ | ----------------------------------------------------------------------------- |
 | `title`            | A short descriptive title of the external ticket. For example, the ticket ID. |
-| `ticketing_system` | One of the [supported ticketing systems](#supported-ticketing-systems).                     |
+| `ticketing_system` | One of the [supported ticketing systems](#supported-ticketing-systems).       |
 | `external_url`     | The URL of the external ticket.                                               |
 | `external_id`      | An arbitrary external identifier for the ticket reference.                    |
 | `finding_id`       | The Cobalt ID of the finding this external ticket belongs to.                 |
@@ -136,7 +163,7 @@ You get a `201` response code for a successful request.
 | ------------------ | ----------------------------------------------------------------------------- |
 | `id`               | A unique ID representing the external ticket reference. Starts with `efr_`    |
 | `title`            | A short descriptive title of the external ticket. For example, the ticket ID. |
-| `ticketing_system` | One of the [supported ticketing systems](#supported-ticketing-systems).                     |
+| `ticketing_system` | One of the [supported ticketing systems](#supported-ticketing-systems).       |
 | `external_url`     | The URL of the external ticket.                                               |
 | `external_id`      | An arbitrary external identifier for the ticket reference.                    |
 | `finding_id`       | The Cobalt ID of the finding this external ticket belongs to.                 |


### PR DESCRIPTION
[FX-4415](https://zombie.atlassian.net/browse/FX-4415)

 - fix: add missing "search by external ID and ticketing system",
 - fix: move the comments next to the shell commands

----

Before:

<img width="475" alt="Screenshot 2024-07-03 at 10 28 08" src="https://github.com/cobalthq/cobalt-api-docs/assets/1405703/9907bc83-898b-47d0-a5b2-70a228ecb7e9">

<img width="536" alt="Screenshot 2024-07-03 at 10 28 13" src="https://github.com/cobalthq/cobalt-api-docs/assets/1405703/76639c02-b388-416c-b282-d91422104bd4">

After

<img width="780" alt="Screenshot 2024-07-03 at 10 26 03" src="https://github.com/cobalthq/cobalt-api-docs/assets/1405703/8959f36d-6942-4a47-bed8-0ef37d4adc4c">

<img width="770" alt="Screenshot 2024-07-03 at 10 26 09" src="https://github.com/cobalthq/cobalt-api-docs/assets/1405703/b9d41560-7823-41ce-9749-20f3c2b81773">


----


Proof that it actually works:

<img width="1183" alt="Screenshot 2024-07-03 at 10 16 30" src="https://github.com/cobalthq/cobalt-api-docs/assets/1405703/d6e1b0d4-19c0-4946-9078-746859f5344e">


<img width="1157" alt="Screenshot 2024-07-03 at 10 16 50" src="https://github.com/cobalthq/cobalt-api-docs/assets/1405703/cb0b8c81-968f-422d-8e35-2bcc98726207">


[FX-4415]: https://zombie.atlassian.net/browse/FX-4415?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

